### PR TITLE
Fixed emocf paths

### DIFF
--- a/data/EmoCF/audio_inputs.jsonl
+++ b/data/EmoCF/audio_inputs.jsonl
@@ -1,1562 +1,1562 @@
-{"filename": "5ea734f39a31b90ee2f7b8e0_aaee06c6_fear.wav", "emotion": "fear", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_aaee06c6_sadness.wav", "emotion": "sadness", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67acae4d2601703808e7e666_4b67c01e_neutral.wav", "emotion": "neutral", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "67acae4d2601703808e7e666_4b67c01e_sadness.wav", "emotion": "sadness", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_88aed7cd_sadness.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_88aed7cd_fear.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "672268205351c30413c9837e_29db99b2_fear.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_29db99b2_surprise.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "66d72124d778efac4645d1d7_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "66d72124d778efac4645d1d7_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_602c826c_disgust.wav", "emotion": "disgust", "sentence": "You're standing too close.", "expected_emotions": ["disgust", "fear"]}
-{"filename": "665be0d7c160ab38d0795255_602c826c_fear.wav", "emotion": "fear", "sentence": "You're standing too close.", "expected_emotions": ["disgust", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_84c95851_fear.wav", "emotion": "fear", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_84c95851_surprise.wav", "emotion": "surprise", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_fbd82b56_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been studying mold all day.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_fbd82b56_disgust.wav", "emotion": "disgust", "sentence": "I just found out I have been studying mold all day.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "6691bc059b0182b0bdd7d682_cf574b19_surprise.wav", "emotion": "surprise", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6691bc059b0182b0bdd7d682_cf574b19_fear.wav", "emotion": "fear", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_6991bbce_sadness.wav", "emotion": "sadness", "sentence": "She finally found all of her missing pieces.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_6991bbce_surprise.wav", "emotion": "surprise", "sentence": "She finally found all of her missing pieces.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "671e372ff616106156f72fd3_fd193ceb_fear.wav", "emotion": "fear", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
-{"filename": "671e372ff616106156f72fd3_fd193ceb_anger.wav", "emotion": "anger", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_dfa5f466_surprise.wav", "emotion": "surprise", "sentence": "He just spilled his drink again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_dfa5f466_sadness.wav", "emotion": "sadness", "sentence": "He just spilled his drink again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6699258fcd1cb9db035de794_54345e2f_fear.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_54345e2f_surprise.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67042cdf06ed4052bdf44c07_9c1cda4d_sadness.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "67042cdf06ed4052bdf44c07_9c1cda4d_disgust.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "66ef1fe508a57ab4d42c952d_c4d7c4ff_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "66ef1fe508a57ab4d42c952d_c4d7c4ff_disgust.wav", "emotion": "disgust", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "5a063c2d844c7a00015e477d_e5fd8745_surprise.wav", "emotion": "surprise", "sentence": "You're going my way!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5a063c2d844c7a00015e477d_e5fd8745_joy.wav", "emotion": "joy", "sentence": "You're going my way!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "664cd1c6545aa0f362493dd9_54345e2f_fear.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664cd1c6545aa0f362493dd9_54345e2f_surprise.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "674ca794941ad6898969714b_aaea7201_surprise.wav", "emotion": "surprise", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "674ca794941ad6898969714b_aaea7201_fear.wav", "emotion": "fear", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_c399918a_surprise.wav", "emotion": "surprise", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_c399918a_sadness.wav", "emotion": "sadness", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6699258fcd1cb9db035de794_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_8a544d8e_surprise.wav", "emotion": "surprise", "sentence": "You're really going to have to learn this quickly.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_8a544d8e_sadness.wav", "emotion": "sadness", "sentence": "You're really going to have to learn this quickly.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_e8c2252f_fear.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_e8c2252f_anger.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
-{"filename": "6699258fcd1cb9db035de794_84c95851_surprise.wav", "emotion": "surprise", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6699258fcd1cb9db035de794_84c95851_fear.wav", "emotion": "fear", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_397ff4dd_fear.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_397ff4dd_surprise.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_dc193dfd_anger.wav", "emotion": "anger", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_dc193dfd_sadness.wav", "emotion": "sadness", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66d72124d778efac4645d1d7_b3f7edf3_joy.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "66d72124d778efac4645d1d7_b3f7edf3_sadness.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_63ee6228_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be holding my old guitar again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_63ee6228_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be holding my old guitar again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_05394151_surprise.wav", "emotion": "surprise", "sentence": "She's cooking alone for the first time.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_05394151_fear.wav", "emotion": "fear", "sentence": "She's cooking alone for the first time.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_0e88c8bd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "677aa09e06098c948784a33c_0e88c8bd_disgust.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "582474a8aac01b0001e45ef9_ac546dc3_sadness.wav", "emotion": "sadness", "sentence": "You are holding my hand.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_ac546dc3_surprise.wav", "emotion": "surprise", "sentence": "You are holding my hand.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_9d81d5a0_surprise.wav", "emotion": "surprise", "sentence": "She saw him staring at her from across the rack of clothes.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "665be0d7c160ab38d0795255_9d81d5a0_disgust.wav", "emotion": "disgust", "sentence": "She saw him staring at her from across the rack of clothes.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "664cf2037353bb98801436b5_f6da94e7_fear.wav", "emotion": "fear", "sentence": "You're going to have your teeth pulled.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_f6da94e7_surprise.wav", "emotion": "surprise", "sentence": "You're going to have your teeth pulled.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_36ea06af_anger.wav", "emotion": "anger", "sentence": "They are ruining their childhood.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_36ea06af_sadness.wav", "emotion": "sadness", "sentence": "They are ruining their childhood.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_0450275d_sadness.wav", "emotion": "sadness", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "677aa09e06098c948784a33c_0450275d_joy.wav", "emotion": "joy", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "67abdd72c863ca5fbe8238cb_0e88c8bd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "67abdd72c863ca5fbe8238cb_0e88c8bd_disgust.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "6419ae0434916e5dde92e2f2_849130dc_sadness.wav", "emotion": "sadness", "sentence": "She can't afford another loss.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_849130dc_fear.wav", "emotion": "fear", "sentence": "She can't afford another loss.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_1da563cd_surprise.wav", "emotion": "surprise", "sentence": "You're really going back for another pastry.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_1da563cd_sadness.wav", "emotion": "sadness", "sentence": "You're really going back for another pastry.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_26f0a4cd_sadness.wav", "emotion": "sadness", "sentence": "He was standing too close to the edge.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66ef1fe508a57ab4d42c952d_26f0a4cd_fear.wav", "emotion": "fear", "sentence": "He was standing too close to the edge.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_641ecfd1_anger.wav", "emotion": "anger", "sentence": "I don't know what you're talking about.", "expected_emotions": ["anger", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_641ecfd1_fear.wav", "emotion": "fear", "sentence": "I don't know what you're talking about.", "expected_emotions": ["anger", "fear"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_2ea359f0_surprise.wav", "emotion": "surprise", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_2ea359f0_anger.wav", "emotion": "anger", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_71ac7ee2_sadness.wav", "emotion": "sadness", "sentence": "She was alone at her table.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_71ac7ee2_fear.wav", "emotion": "fear", "sentence": "She was alone at her table.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "664a9130e765f4b066ec179e_9d28cb8d_sadness.wav", "emotion": "sadness", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "664a9130e765f4b066ec179e_9d28cb8d_anger.wav", "emotion": "anger", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "661e7aea959de3433a8f255d_bb52af9f_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661e7aea959de3433a8f255d_bb52af9f_fear.wav", "emotion": "fear", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67876285103f57f54f701beb_e871f202_surprise.wav", "emotion": "surprise", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67876285103f57f54f701beb_e871f202_sadness.wav", "emotion": "sadness", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66c019586569ea36287bd523_f9455e1f_sadness.wav", "emotion": "sadness", "sentence": "You're still not here.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "66c019586569ea36287bd523_f9455e1f_anger.wav", "emotion": "anger", "sentence": "You're still not here.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_645d382a_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_645d382a_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_dfa5f466_sadness.wav", "emotion": "sadness", "sentence": "He just spilled his drink again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_dfa5f466_surprise.wav", "emotion": "surprise", "sentence": "He just spilled his drink again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_0bf6bf5c_sadness.wav", "emotion": "sadness", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "667c86d3b9ca760b999914f3_0bf6bf5c_fear.wav", "emotion": "fear", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_34032b75_neutral.wav", "emotion": "neutral", "sentence": "You are dancing.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_34032b75_surprise.wav", "emotion": "surprise", "sentence": "You are dancing.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_b469ae9d_fear.wav", "emotion": "fear", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_b469ae9d_surprise.wav", "emotion": "surprise", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "674d1412e0b30ad8c359b635_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "674d1412e0b30ad8c359b635_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_f5565a5c_fear.wav", "emotion": "fear", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_f5565a5c_surprise.wav", "emotion": "surprise", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_5dafd801_fear.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_5dafd801_surprise.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_1ffe7629_fear.wav", "emotion": "fear", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_1ffe7629_surprise.wav", "emotion": "surprise", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_adf9d846_surprise.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "672268205351c30413c9837e_adf9d846_neutral.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "67acb9892d24db4d61a856f5_e1a5e526_anger.wav", "emotion": "anger", "sentence": "I just got hit by another stray ball.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "67acb9892d24db4d61a856f5_e1a5e526_surprise.wav", "emotion": "surprise", "sentence": "I just got hit by another stray ball.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_aaea7201_surprise.wav", "emotion": "surprise", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "63ffcb367b500c516d0648a2_aaea7201_fear.wav", "emotion": "fear", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_66788940_surprise.wav", "emotion": "surprise", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_66788940_fear.wav", "emotion": "fear", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672268205351c30413c9837e_6471ed10_surprise.wav", "emotion": "surprise", "sentence": "He just spent his last quarter.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672268205351c30413c9837e_6471ed10_sadness.wav", "emotion": "sadness", "sentence": "He just spent his last quarter.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "666f76b68b89442817be678a_be99fd79_anger.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
-{"filename": "666f76b68b89442817be678a_be99fd79_sadness.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67acae4d2601703808e7e666_8dafb30d_surprise.wav", "emotion": "surprise", "sentence": "You're going deeper into these woods.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acae4d2601703808e7e666_8dafb30d_fear.wav", "emotion": "fear", "sentence": "You're going deeper into these woods.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664cd1c6545aa0f362493dd9_88aed7cd_sadness.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "664cd1c6545aa0f362493dd9_88aed7cd_fear.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_708a33d7_anger.wav", "emotion": "anger", "sentence": "I cant believe I just spilled coffee all over my shirt.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_708a33d7_surprise.wav", "emotion": "surprise", "sentence": "I cant believe I just spilled coffee all over my shirt.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_e01c28d8_anger.wav", "emotion": "anger", "sentence": "He lost his favorite pair of work gloves.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_e01c28d8_sadness.wav", "emotion": "sadness", "sentence": "He lost his favorite pair of work gloves.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6712795a5e34ccb89d7fd40d_5260adbc_surprise.wav", "emotion": "surprise", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6712795a5e34ccb89d7fd40d_5260adbc_fear.wav", "emotion": "fear", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "671e372ff616106156f72fd3_9be88a8f_sadness.wav", "emotion": "sadness", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "671e372ff616106156f72fd3_9be88a8f_disgust.wav", "emotion": "disgust", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_3b1b098d_surprise.wav", "emotion": "surprise", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_3b1b098d_anger.wav", "emotion": "anger", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["surprise", "anger"]}
-{"filename": "668758de3a65db8f01f8ee7f_14d1943e_surprise.wav", "emotion": "surprise", "sentence": "She left her stove burning.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "668758de3a65db8f01f8ee7f_14d1943e_neutral.wav", "emotion": "neutral", "sentence": "She left her stove burning.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_a7e07b6e_surprise.wav", "emotion": "surprise", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_a7e07b6e_fear.wav", "emotion": "fear", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66439c275cd3cf1ee2426935_15b86f58_surprise.wav", "emotion": "surprise", "sentence": "She saw him walking towards her wearing an unfamiliar red afro.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66439c275cd3cf1ee2426935_15b86f58_fear.wav", "emotion": "fear", "sentence": "She saw him walking towards her wearing an unfamiliar red afro.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acae4d2601703808e7e666_c4d7c4ff_disgust.wav", "emotion": "disgust", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_c4d7c4ff_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_e7546e45_surprise.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664a6bbe21031d20a2155427_e7546e45_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67876285103f57f54f701beb_04e8dbf3_fear.wav", "emotion": "fear", "sentence": "You just kicked over your urine sample.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_04e8dbf3_surprise.wav", "emotion": "surprise", "sentence": "You just kicked over your urine sample.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "667c86d3b9ca760b999914f3_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6732de5c32981eeab9c67bd1_86d9911c_joy.wav", "emotion": "joy", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_86d9911c_surprise.wav", "emotion": "surprise", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_98b656e7_surprise.wav", "emotion": "surprise", "sentence": "I can feel my heart pounding along with this rhythm.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_98b656e7_fear.wav", "emotion": "fear", "sentence": "I can feel my heart pounding along with this rhythm.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "667c86d3b9ca760b999914f3_be319ba8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_be319ba8_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_9bd526d3_fear.wav", "emotion": "fear", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_9bd526d3_surprise.wav", "emotion": "surprise", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664f98c80beb5400a141ac91_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6600d4ab3d166502ff03c3aa_77a6efc8_anger.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6600d4ab3d166502ff03c3aa_77a6efc8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_397ff4dd_fear.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "662facfffb363cef00e404a8_397ff4dd_surprise.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_08cde112_surprise.wav", "emotion": "surprise", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_08cde112_fear.wav", "emotion": "fear", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664cf2037353bb98801436b5_2031af6e_joy.wav", "emotion": "joy", "sentence": "I just threw my favorite rose bouquet into the orchestra pit.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "664cf2037353bb98801436b5_2031af6e_sadness.wav", "emotion": "sadness", "sentence": "I just threw my favorite rose bouquet into the orchestra pit.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_97d9e52f_fear.wav", "emotion": "fear", "sentence": "He was trapped.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_97d9e52f_sadness.wav", "emotion": "sadness", "sentence": "He was trapped.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "667c86d3b9ca760b999914f3_d8b58e4d_anger.wav", "emotion": "anger", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_d8b58e4d_surprise.wav", "emotion": "surprise", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_cf574b19_fear.wav", "emotion": "fear", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_cf574b19_surprise.wav", "emotion": "surprise", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a9130e765f4b066ec179e_a93a0fd0_fear.wav", "emotion": "fear", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a9130e765f4b066ec179e_a93a0fd0_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_79eb3f50_fear.wav", "emotion": "fear", "sentence": "You're going to be late for your exam!", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_79eb3f50_surprise.wav", "emotion": "surprise", "sentence": "You're going to be late for your exam!", "expected_emotions": ["fear", "surprise"]}
-{"filename": "662facfffb363cef00e404a8_b3f7edf3_sadness.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "662facfffb363cef00e404a8_b3f7edf3_joy.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "674ca794941ad6898969714b_d9f22bd6_fear.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["fear", "joy"]}
-{"filename": "674ca794941ad6898969714b_d9f22bd6_joy.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["fear", "joy"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_6e6d7014_sadness.wav", "emotion": "sadness", "sentence": "I have been forced into participating in this pointless ritual again.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_6e6d7014_anger.wav", "emotion": "anger", "sentence": "I have been forced into participating in this pointless ritual again.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "662facfffb363cef00e404a8_e7546e45_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "662facfffb363cef00e404a8_e7546e45_surprise.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_be99fd79_sadness.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_be99fd79_anger.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_2ea359f0_anger.wav", "emotion": "anger", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_2ea359f0_surprise.wav", "emotion": "surprise", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_efe68913_surprise.wav", "emotion": "surprise", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6712795a5e34ccb89d7fd40d_efe68913_neutral.wav", "emotion": "neutral", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "674d1412e0b30ad8c359b635_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "674d1412e0b30ad8c359b635_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea196f089935b04d2ee69d9_c146ebb3_fear.wav", "emotion": "fear", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5ea196f089935b04d2ee69d9_c146ebb3_surprise.wav", "emotion": "surprise", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5ea196f089935b04d2ee69d9_041712e6_sadness.wav", "emotion": "sadness", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "5ea196f089935b04d2ee69d9_041712e6_joy.wav", "emotion": "joy", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "6600d4ab3d166502ff03c3aa_f26bfaa5_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6600d4ab3d166502ff03c3aa_f26bfaa5_fear.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "674ca794941ad6898969714b_02da40a9_sadness.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "674ca794941ad6898969714b_02da40a9_fear.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "671e372ff616106156f72fd3_be99fd79_sadness.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
-{"filename": "671e372ff616106156f72fd3_be99fd79_anger.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
-{"filename": "664cf2037353bb98801436b5_4d256388_sadness.wav", "emotion": "sadness", "sentence": "I can't believe I wasted my entire day printing out these useless documents.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "664cf2037353bb98801436b5_4d256388_anger.wav", "emotion": "anger", "sentence": "I can't believe I wasted my entire day printing out these useless documents.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "661bd496ed5e403f399787c8_e1dd3a2e_surprise.wav", "emotion": "surprise", "sentence": "He just walked into his old house.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661bd496ed5e403f399787c8_e1dd3a2e_fear.wav", "emotion": "fear", "sentence": "He just walked into his old house.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_9615b184_surprise.wav", "emotion": "surprise", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_9615b184_sadness.wav", "emotion": "sadness", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_4d4ba71d_sadness.wav", "emotion": "sadness", "sentence": "She had been working at this job long enough.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_4d4ba71d_disgust.wav", "emotion": "disgust", "sentence": "She had been working at this job long enough.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "6691bc059b0182b0bdd7d682_a7e07b6e_fear.wav", "emotion": "fear", "sentence": "You are about to perform your first solo.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_a7e07b6e_surprise.wav", "emotion": "surprise", "sentence": "You are about to perform your first solo.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_a6cda68d_fear.wav", "emotion": "fear", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_a6cda68d_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_e8c2252f_anger.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["anger", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_e8c2252f_fear.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["anger", "fear"]}
-{"filename": "664cf2037353bb98801436b5_8d21e826_sadness.wav", "emotion": "sadness", "sentence": "I'm going for a walk alone.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "664cf2037353bb98801436b5_8d21e826_anger.wav", "emotion": "anger", "sentence": "I'm going for a walk alone.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "63ffcb367b500c516d0648a2_f75b7f35_surprise.wav", "emotion": "surprise", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "63ffcb367b500c516d0648a2_f75b7f35_fear.wav", "emotion": "fear", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_552a6412_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_552a6412_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66a0fd20a0cc806dd6cd8e82_7767ecd6_fear.wav", "emotion": "fear", "sentence": "I just saw someone I know from my past walk into this auditorium.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66a0fd20a0cc806dd6cd8e82_7767ecd6_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone I know from my past walk into this auditorium.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_f6e9e7d8_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone I didn't expect here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_f6e9e7d8_fear.wav", "emotion": "fear", "sentence": "I just saw someone I didn't expect here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_d8b58e4d_surprise.wav", "emotion": "surprise", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_d8b58e4d_anger.wav", "emotion": "anger", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_645d382a_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_645d382a_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_d70e5b83_sadness.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_d70e5b83_surprise.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_19b9c124_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66a41af57b243259af76b1c3_19b9c124_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67876285103f57f54f701beb_69f2785a_neutral.wav", "emotion": "neutral", "sentence": "The crowd was silent after he fell off his horse.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "67876285103f57f54f701beb_69f2785a_sadness.wav", "emotion": "sadness", "sentence": "The crowd was silent after he fell off his horse.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "582474a8aac01b0001e45ef9_0764bf5e_surprise.wav", "emotion": "surprise", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "582474a8aac01b0001e45ef9_0764bf5e_fear.wav", "emotion": "fear", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_f75b7f35_surprise.wav", "emotion": "surprise", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_f75b7f35_fear.wav", "emotion": "fear", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_91ea0275_disgust.wav", "emotion": "disgust", "sentence": "I just threw away my career.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_91ea0275_sadness.wav", "emotion": "sadness", "sentence": "I just threw away my career.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6600d4ab3d166502ff03c3aa_3b1b098d_anger.wav", "emotion": "anger", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_3b1b098d_surprise.wav", "emotion": "surprise", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
-{"filename": "666f76b68b89442817be678a_4e26cfc5_fear.wav", "emotion": "fear", "sentence": "I just felt something move under my bed.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "666f76b68b89442817be678a_4e26cfc5_surprise.wav", "emotion": "surprise", "sentence": "I just felt something move under my bed.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_b1f4c50b_surprise.wav", "emotion": "surprise", "sentence": "You're going outside alone at night?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_b1f4c50b_fear.wav", "emotion": "fear", "sentence": "You're going outside alone at night?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67806e9d273c2547826d1d8b_8231ce30_surprise.wav", "emotion": "surprise", "sentence": "I had no idea people actually did this at campsites.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "67806e9d273c2547826d1d8b_8231ce30_disgust.wav", "emotion": "disgust", "sentence": "I had no idea people actually did this at campsites.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "664a6bbe21031d20a2155427_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_c7c10b53_sadness.wav", "emotion": "sadness", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_c7c10b53_fear.wav", "emotion": "fear", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67876285103f57f54f701beb_22d8da52_anger.wav", "emotion": "anger", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
-{"filename": "67876285103f57f54f701beb_22d8da52_surprise.wav", "emotion": "surprise", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_a932e2da_surprise.wav", "emotion": "surprise", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_a932e2da_sadness.wav", "emotion": "sadness", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_e46f81c9_neutral.wav", "emotion": "neutral", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_e46f81c9_surprise.wav", "emotion": "surprise", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_2afb09ee_neutral.wav", "emotion": "neutral", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_2afb09ee_sadness.wav", "emotion": "sadness", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "672268205351c30413c9837e_297cb01d_fear.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_297cb01d_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_44a56ee0_surprise.wav", "emotion": "surprise", "sentence": "I just lost my favorite racket.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672268205351c30413c9837e_44a56ee0_sadness.wav", "emotion": "sadness", "sentence": "I just lost my favorite racket.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6732de5c32981eeab9c67bd1_55d9ab65_surprise.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6732de5c32981eeab9c67bd1_55d9ab65_fear.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_bca7cbef_surprise.wav", "emotion": "surprise", "sentence": "She was dancing alone at night near an abandoned stadium.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_bca7cbef_fear.wav", "emotion": "fear", "sentence": "She was dancing alone at night near an abandoned stadium.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_cde4a4dd_surprise.wav", "emotion": "surprise", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_cde4a4dd_joy.wav", "emotion": "joy", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_ce2be7cb_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_ce2be7cb_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66a41af57b243259af76b1c3_eacff021_fear.wav", "emotion": "fear", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "66a41af57b243259af76b1c3_eacff021_sadness.wav", "emotion": "sadness", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_305f21d9_surprise.wav", "emotion": "surprise", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_305f21d9_fear.wav", "emotion": "fear", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_088de02f_surprise.wav", "emotion": "surprise", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "5e4b4332e210130619b398c3_088de02f_neutral.wav", "emotion": "neutral", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_ec3ee8d6_surprise.wav", "emotion": "surprise", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_ec3ee8d6_fear.wav", "emotion": "fear", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "666f76b68b89442817be678a_c2679c77_surprise.wav", "emotion": "surprise", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "666f76b68b89442817be678a_c2679c77_fear.wav", "emotion": "fear", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67876285103f57f54f701beb_f781e749_surprise.wav", "emotion": "surprise", "sentence": "You are going into this blind.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67876285103f57f54f701beb_f781e749_fear.wav", "emotion": "fear", "sentence": "You are going into this blind.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_272f9640_sadness.wav", "emotion": "sadness", "sentence": "She was alone at home.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_272f9640_fear.wav", "emotion": "fear", "sentence": "She was alone at home.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_fae6c996_anger.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_fae6c996_surprise.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_02da40a9_sadness.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_02da40a9_fear.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_f5995111_fear.wav", "emotion": "fear", "sentence": "You are going to have to present your project today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_f5995111_surprise.wav", "emotion": "surprise", "sentence": "You are going to have to present your project today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_f9533209_surprise.wav", "emotion": "surprise", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_f9533209_fear.wav", "emotion": "fear", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a6bbe21031d20a2155427_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "664a6bbe21031d20a2155427_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_1937a910_fear.wav", "emotion": "fear", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_1937a910_surprise.wav", "emotion": "surprise", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_7e67e4c6_surprise.wav", "emotion": "surprise", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66c87644a4f4b16d885298dc_7e67e4c6_fear.wav", "emotion": "fear", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_adf9d846_neutral.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_adf9d846_surprise.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_b70788d1_sadness.wav", "emotion": "sadness", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_b70788d1_fear.wav", "emotion": "fear", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_0e88c8bd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "6419ae0434916e5dde92e2f2_0e88c8bd_disgust.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "6711e09a6906af2fa5b782bd_70161243_fear.wav", "emotion": "fear", "sentence": "She brought an enormous suitcase onto the crowded city bus.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_70161243_surprise.wav", "emotion": "surprise", "sentence": "She brought an enormous suitcase onto the crowded city bus.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_8a26760e_anger.wav", "emotion": "anger", "sentence": "She was crying alone at the edge of the ocean.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "672268205351c30413c9837e_8a26760e_sadness.wav", "emotion": "sadness", "sentence": "She was crying alone at the edge of the ocean.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66c87644a4f4b16d885298dc_a7c5ffec_anger.wav", "emotion": "anger", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66c87644a4f4b16d885298dc_a7c5ffec_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_31f0d737_surprise.wav", "emotion": "surprise", "sentence": "You are leaving.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_31f0d737_sadness.wav", "emotion": "sadness", "sentence": "You are leaving.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66439c275cd3cf1ee2426935_c67dbe3c_surprise.wav", "emotion": "surprise", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66439c275cd3cf1ee2426935_c67dbe3c_sadness.wav", "emotion": "sadness", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6600d4ab3d166502ff03c3aa_db88a003_joy.wav", "emotion": "joy", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_db88a003_surprise.wav", "emotion": "surprise", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_54345e2f_fear.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_54345e2f_surprise.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "675ef1840636ec90d906ea28_630589fb_disgust.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "675ef1840636ec90d906ea28_630589fb_sadness.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_80a36bd8_surprise.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "66ef1fe508a57ab4d42c952d_80a36bd8_anger.wav", "emotion": "anger", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67abdd72c863ca5fbe8238cb_1937a910_fear.wav", "emotion": "fear", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_1937a910_surprise.wav", "emotion": "surprise", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_962e3fd1_surprise.wav", "emotion": "surprise", "sentence": "You're actually watching this movie alone after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_962e3fd1_sadness.wav", "emotion": "sadness", "sentence": "You're actually watching this movie alone after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_55d9ab65_surprise.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_55d9ab65_fear.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "668758de3a65db8f01f8ee7f_fbb36a57_fear.wav", "emotion": "fear", "sentence": "She changed all of her door's locks.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "668758de3a65db8f01f8ee7f_fbb36a57_sadness.wav", "emotion": "sadness", "sentence": "She changed all of her door's locks.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67876285103f57f54f701beb_7e67e4c6_fear.wav", "emotion": "fear", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_7e67e4c6_surprise.wav", "emotion": "surprise", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_ea4d3e21_surprise.wav", "emotion": "surprise", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6619cb1e30cb95691a6dd425_ea4d3e21_fear.wav", "emotion": "fear", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6699258fcd1cb9db035de794_be319ba8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_be319ba8_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_f75b7f35_fear.wav", "emotion": "fear", "sentence": "You're going up into the air right now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_f75b7f35_surprise.wav", "emotion": "surprise", "sentence": "You're going up into the air right now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_f2e7aa58_surprise.wav", "emotion": "surprise", "sentence": "He was wearing only his Speedos and running towards her.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_f2e7aa58_fear.wav", "emotion": "fear", "sentence": "He was wearing only his Speedos and running towards her.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_81774650_surprise.wav", "emotion": "surprise", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_81774650_neutral.wav", "emotion": "neutral", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_25968f77_joy.wav", "emotion": "joy", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_25968f77_surprise.wav", "emotion": "surprise", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_db88a003_surprise.wav", "emotion": "surprise", "sentence": "You are going to love this flight.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_db88a003_joy.wav", "emotion": "joy", "sentence": "You are going to love this flight.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_d585c456_surprise.wav", "emotion": "surprise", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_d585c456_fear.wav", "emotion": "fear", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_31f0d737_sadness.wav", "emotion": "sadness", "sentence": "You are leaving.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_31f0d737_surprise.wav", "emotion": "surprise", "sentence": "You are leaving.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_3a810787_sadness.wav", "emotion": "sadness", "sentence": "I have some bad news.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_3a810787_fear.wav", "emotion": "fear", "sentence": "I have some bad news.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_c0c720e8_fear.wav", "emotion": "fear", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_c0c720e8_surprise.wav", "emotion": "surprise", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "675ef1840636ec90d906ea28_eacff021_sadness.wav", "emotion": "sadness", "sentence": "She will be alone tonight.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "675ef1840636ec90d906ea28_eacff021_fear.wav", "emotion": "fear", "sentence": "She will be alone tonight.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_c6f0cf65_sadness.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_c6f0cf65_surprise.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_adf9d846_neutral.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_adf9d846_surprise.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "672268205351c30413c9837e_b469ae9d_fear.wav", "emotion": "fear", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_b469ae9d_surprise.wav", "emotion": "surprise", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_cd67923b_surprise.wav", "emotion": "surprise", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6712795a5e34ccb89d7fd40d_cd67923b_fear.wav", "emotion": "fear", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acae4d2601703808e7e666_52ceff23_disgust.wav", "emotion": "disgust", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_52ceff23_surprise.wav", "emotion": "surprise", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_e46f81c9_neutral.wav", "emotion": "neutral", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_e46f81c9_surprise.wav", "emotion": "surprise", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67876285103f57f54f701beb_063d0542_sadness.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67876285103f57f54f701beb_063d0542_surprise.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_fcafe5e5_fear.wav", "emotion": "fear", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_fcafe5e5_sadness.wav", "emotion": "sadness", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_4b67c01e_neutral.wav", "emotion": "neutral", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_4b67c01e_sadness.wav", "emotion": "sadness", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "5e4b4332e210130619b398c3_c7c10b53_fear.wav", "emotion": "fear", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5e4b4332e210130619b398c3_c7c10b53_sadness.wav", "emotion": "sadness", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_9c1cda4d_disgust.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_9c1cda4d_sadness.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "664f98c80beb5400a141ac91_198f3011_surprise.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664f98c80beb5400a141ac91_198f3011_sadness.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6789b046961fcf908d886644_979a2dd6_joy.wav", "emotion": "joy", "sentence": "You just got kissed by your favorite nurse.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6789b046961fcf908d886644_979a2dd6_surprise.wav", "emotion": "surprise", "sentence": "You just got kissed by your favorite nurse.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "67806e9d273c2547826d1d8b_82784882_sadness.wav", "emotion": "sadness", "sentence": "You're actually taking responsibility for your actions.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67806e9d273c2547826d1d8b_82784882_surprise.wav", "emotion": "surprise", "sentence": "You're actually taking responsibility for your actions.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "675ef1840636ec90d906ea28_890bee09_surprise.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "675ef1840636ec90d906ea28_890bee09_sadness.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_3ea21e2d_surprise.wav", "emotion": "surprise", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6691bc059b0182b0bdd7d682_3ea21e2d_fear.wav", "emotion": "fear", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a9130e765f4b066ec179e_c7c10b53_fear.wav", "emotion": "fear", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "664a9130e765f4b066ec179e_c7c10b53_sadness.wav", "emotion": "sadness", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_462143e1_surprise.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_462143e1_fear.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6732de5c32981eeab9c67bd1_f26bfaa5_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6732de5c32981eeab9c67bd1_f26bfaa5_fear.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_0450275d_sadness.wav", "emotion": "sadness", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "5a063c2d844c7a00015e477d_0450275d_joy.wav", "emotion": "joy", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "5dd72d2883e3096d755c0f14_927aca5f_surprise.wav", "emotion": "surprise", "sentence": "I just saw something move out of my eye corner while I was spinning.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_927aca5f_fear.wav", "emotion": "fear", "sentence": "I just saw something move out of my eye corner while I was spinning.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6699258fcd1cb9db035de794_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_8f4e8c06_surprise.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
-{"filename": "66c87644a4f4b16d885298dc_8f4e8c06_anger.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
-{"filename": "662facfffb363cef00e404a8_48581123_anger.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_48581123_sadness.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6732de5c32981eeab9c67bd1_b6fe0734_fear.wav", "emotion": "fear", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_b6fe0734_surprise.wav", "emotion": "surprise", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_c6f0cf65_sadness.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_c6f0cf65_surprise.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_630589fb_disgust.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_630589fb_sadness.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "667c86d3b9ca760b999914f3_5dafd801_surprise.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "667c86d3b9ca760b999914f3_5dafd801_fear.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672941064eee8977e7916b37_1adddb75_surprise.wav", "emotion": "surprise", "sentence": "You're still wearing those old sandals.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672941064eee8977e7916b37_1adddb75_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing those old sandals.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "661e7aea959de3433a8f255d_1a0fd4ad_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "661e7aea959de3433a8f255d_1a0fd4ad_sadness.wav", "emotion": "sadness", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5e4b4332e210130619b398c3_2d82a2b1_fear.wav", "emotion": "fear", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_2d82a2b1_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_00e2698f_anger.wav", "emotion": "anger", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_00e2698f_surprise.wav", "emotion": "surprise", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6699258fcd1cb9db035de794_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6711e09a6906af2fa5b782bd_c67e8d8e_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6711e09a6906af2fa5b782bd_c67e8d8e_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6712795a5e34ccb89d7fd40d_3fdbf166_anger.wav", "emotion": "anger", "sentence": "You're going too far out there.", "expected_emotions": ["anger", "fear"]}
-{"filename": "6712795a5e34ccb89d7fd40d_3fdbf166_fear.wav", "emotion": "fear", "sentence": "You're going too far out there.", "expected_emotions": ["anger", "fear"]}
-{"filename": "66463e4efb99fba5a67a010a_57b41e36_anger.wav", "emotion": "anger", "sentence": "I just got yelled at by my boss for not meeting this deadline.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66463e4efb99fba5a67a010a_57b41e36_sadness.wav", "emotion": "sadness", "sentence": "I just got yelled at by my boss for not meeting this deadline.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_f2b4276b_sadness.wav", "emotion": "sadness", "sentence": "I'm running low again.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "677aa09e06098c948784a33c_f2b4276b_neutral.wav", "emotion": "neutral", "sentence": "I'm running low again.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "582474a8aac01b0001e45ef9_297cb01d_fear.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_297cb01d_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_0e88c8bd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "664a6bbe21031d20a2155427_0e88c8bd_disgust.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "664a9130e765f4b066ec179e_5fe74091_neutral.wav", "emotion": "neutral", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "664a9130e765f4b066ec179e_5fe74091_surprise.wav", "emotion": "surprise", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6745731e75a88802a56be3ef_c67dbe3c_sadness.wav", "emotion": "sadness", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6745731e75a88802a56be3ef_c67dbe3c_surprise.wav", "emotion": "surprise", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_c0df236b_surprise.wav", "emotion": "surprise", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "582474a8aac01b0001e45ef9_c0df236b_sadness.wav", "emotion": "sadness", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_a5df2c69_surprise.wav", "emotion": "surprise", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_a5df2c69_fear.wav", "emotion": "fear", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672268205351c30413c9837e_d117b8ee_anger.wav", "emotion": "anger", "sentence": "I don't want to go outside for recess.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "672268205351c30413c9837e_d117b8ee_sadness.wav", "emotion": "sadness", "sentence": "I don't want to go outside for recess.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "665be0d7c160ab38d0795255_d73d6e43_surprise.wav", "emotion": "surprise", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "665be0d7c160ab38d0795255_d73d6e43_fear.wav", "emotion": "fear", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_5b58dbed_surprise.wav", "emotion": "surprise", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_5b58dbed_fear.wav", "emotion": "fear", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67042cdf06ed4052bdf44c07_0764bf5e_surprise.wav", "emotion": "surprise", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67042cdf06ed4052bdf44c07_0764bf5e_fear.wav", "emotion": "fear", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_b3f7edf3_joy.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_b3f7edf3_sadness.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_9952d4d4_neutral.wav", "emotion": "neutral", "sentence": "You are cleaning up after everyone else again.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_9952d4d4_sadness.wav", "emotion": "sadness", "sentence": "You are cleaning up after everyone else again.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_fa40c122_surprise.wav", "emotion": "surprise", "sentence": "She never thought she would see him again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_fa40c122_sadness.wav", "emotion": "sadness", "sentence": "She never thought she would see him again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66c87644a4f4b16d885298dc_ac546dc3_surprise.wav", "emotion": "surprise", "sentence": "You are holding my hand.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66c87644a4f4b16d885298dc_ac546dc3_sadness.wav", "emotion": "sadness", "sentence": "You are holding my hand.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672bbb444ab4546a33718004_a7c5ffec_anger.wav", "emotion": "anger", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "672bbb444ab4546a33718004_a7c5ffec_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "667c86d3b9ca760b999914f3_89f649f9_surprise.wav", "emotion": "surprise", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "667c86d3b9ca760b999914f3_89f649f9_joy.wav", "emotion": "joy", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "67aca3ffca27d4b3908a7adc_702585e4_disgust.wav", "emotion": "disgust", "sentence": "She was picking her children up late again.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_702585e4_surprise.wav", "emotion": "surprise", "sentence": "She was picking her children up late again.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_35000989_sadness.wav", "emotion": "sadness", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "6712795a5e34ccb89d7fd40d_35000989_anger.wav", "emotion": "anger", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5ea196f089935b04d2ee69d9_131920dd_sadness.wav", "emotion": "sadness", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5ea196f089935b04d2ee69d9_131920dd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_640a5eb2_neutral.wav", "emotion": "neutral", "sentence": "You are going ahead and doing this.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_640a5eb2_surprise.wav", "emotion": "surprise", "sentence": "You are going ahead and doing this.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67876285103f57f54f701beb_ff00d689_surprise.wav", "emotion": "surprise", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67876285103f57f54f701beb_ff00d689_fear.wav", "emotion": "fear", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6745731e75a88802a56be3ef_5b26beac_neutral.wav", "emotion": "neutral", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6745731e75a88802a56be3ef_5b26beac_surprise.wav", "emotion": "surprise", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_b67adb64_joy.wav", "emotion": "joy", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_b67adb64_surprise.wav", "emotion": "surprise", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_9c1cda4d_sadness.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "63ffcb367b500c516d0648a2_9c1cda4d_disgust.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "604bd44cb5668ba12cc9376e_fcafe5e5_fear.wav", "emotion": "fear", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "604bd44cb5668ba12cc9376e_fcafe5e5_sadness.wav", "emotion": "sadness", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_98b7ce91_sadness.wav", "emotion": "sadness", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_98b7ce91_fear.wav", "emotion": "fear", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_2715fa16_surprise.wav", "emotion": "surprise", "sentence": "Are you actually going up there and saying those things out loud?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_2715fa16_fear.wav", "emotion": "fear", "sentence": "Are you actually going up there and saying those things out loud?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "667c86d3b9ca760b999914f3_063d0542_sadness.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_063d0542_surprise.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_9598b70a_surprise.wav", "emotion": "surprise", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661bd496ed5e403f399787c8_9598b70a_fear.wav", "emotion": "fear", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_d9f22bd6_joy.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_d9f22bd6_fear.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_bb662746_sadness.wav", "emotion": "sadness", "sentence": "She had been feeding them for years but now they were gone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_bb662746_fear.wav", "emotion": "fear", "sentence": "She had been feeding them for years but now they were gone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6619cb1e30cb95691a6dd425_1a0fd4ad_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6619cb1e30cb95691a6dd425_1a0fd4ad_sadness.wav", "emotion": "sadness", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "666f76b68b89442817be678a_d6d98405_sadness.wav", "emotion": "sadness", "sentence": "She was going outside alone at night.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "666f76b68b89442817be678a_d6d98405_fear.wav", "emotion": "fear", "sentence": "She was going outside alone at night.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_d70e5b83_sadness.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_d70e5b83_surprise.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672268205351c30413c9837e_9b7ba3ed_fear.wav", "emotion": "fear", "sentence": "You're sailing alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_9b7ba3ed_surprise.wav", "emotion": "surprise", "sentence": "You're sailing alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_d51fa66b_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be learning about this topic.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_d51fa66b_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be learning about this topic.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_f07f32e1_sadness.wav", "emotion": "sadness", "sentence": "I just sold my last roll of film.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "664cf2037353bb98801436b5_f07f32e1_joy.wav", "emotion": "joy", "sentence": "I just sold my last roll of film.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "672268205351c30413c9837e_400d7b33_fear.wav", "emotion": "fear", "sentence": "He yelled at her.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_400d7b33_surprise.wav", "emotion": "surprise", "sentence": "He yelled at her.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_6c0fd2e6_fear.wav", "emotion": "fear", "sentence": "She heard footsteps coming from inside.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_6c0fd2e6_surprise.wav", "emotion": "surprise", "sentence": "She heard footsteps coming from inside.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_90e2aa2d_neutral.wav", "emotion": "neutral", "sentence": "You're actually standing close enough for me to see your eyes.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_90e2aa2d_surprise.wav", "emotion": "surprise", "sentence": "You're actually standing close enough for me to see your eyes.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66ef1fe508a57ab4d42c952d_01c044ce_fear.wav", "emotion": "fear", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_01c044ce_sadness.wav", "emotion": "sadness", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6789b046961fcf908d886644_3ab3a94d_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd see them end up together like this.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6789b046961fcf908d886644_3ab3a94d_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd see them end up together like this.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_bb52af9f_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_bb52af9f_fear.wav", "emotion": "fear", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6691bc059b0182b0bdd7d682_ae399ff1_surprise.wav", "emotion": "surprise", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6691bc059b0182b0bdd7d682_ae399ff1_fear.wav", "emotion": "fear", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acae4d2601703808e7e666_4a025bc4_disgust.wav", "emotion": "disgust", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_4a025bc4_surprise.wav", "emotion": "surprise", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_66788940_surprise.wav", "emotion": "surprise", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_66788940_fear.wav", "emotion": "fear", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_274677c6_fear.wav", "emotion": "fear", "sentence": "She has never cooked anything like this before.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_274677c6_surprise.wav", "emotion": "surprise", "sentence": "She has never cooked anything like this before.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_7e67e4c6_fear.wav", "emotion": "fear", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_7e67e4c6_surprise.wav", "emotion": "surprise", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_298030a7_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acae4d2601703808e7e666_298030a7_fear.wav", "emotion": "fear", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_088de02f_surprise.wav", "emotion": "surprise", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_088de02f_neutral.wav", "emotion": "neutral", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_298030a7_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_298030a7_fear.wav", "emotion": "fear", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_e7546e45_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_e7546e45_surprise.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672268205351c30413c9837e_c0c720e8_surprise.wav", "emotion": "surprise", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672268205351c30413c9837e_c0c720e8_fear.wav", "emotion": "fear", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66c87644a4f4b16d885298dc_29db99b2_surprise.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66c87644a4f4b16d885298dc_29db99b2_fear.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6732de5c32981eeab9c67bd1_645d382a_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6732de5c32981eeab9c67bd1_645d382a_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_3a069973_surprise.wav", "emotion": "surprise", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_3a069973_neutral.wav", "emotion": "neutral", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "67aca3ffca27d4b3908a7adc_2bd8764d_fear.wav", "emotion": "fear", "sentence": "You're eating your sandwich under my bed.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_2bd8764d_surprise.wav", "emotion": "surprise", "sentence": "You're eating your sandwich under my bed.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ef1fe508a57ab4d42c952d_d75b90fa_fear.wav", "emotion": "fear", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ef1fe508a57ab4d42c952d_d75b90fa_surprise.wav", "emotion": "surprise", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_645d382a_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_645d382a_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_b2eb25bd_neutral.wav", "emotion": "neutral", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_b2eb25bd_surprise.wav", "emotion": "surprise", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_e0083694_fear.wav", "emotion": "fear", "sentence": "You're asking me for help.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_e0083694_surprise.wav", "emotion": "surprise", "sentence": "You're asking me for help.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_e5fd8745_joy.wav", "emotion": "joy", "sentence": "You're going my way!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_e5fd8745_surprise.wav", "emotion": "surprise", "sentence": "You're going my way!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "672268205351c30413c9837e_fb5dae16_surprise.wav", "emotion": "surprise", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672268205351c30413c9837e_fb5dae16_fear.wav", "emotion": "fear", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_946f2703_sadness.wav", "emotion": "sadness", "sentence": "You are not doing your job.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5e4b4332e210130619b398c3_946f2703_anger.wav", "emotion": "anger", "sentence": "You are not doing your job.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "675ef1840636ec90d906ea28_d9f22bd6_joy.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "675ef1840636ec90d906ea28_d9f22bd6_fear.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "668758de3a65db8f01f8ee7f_68bec48f_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be singing here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "668758de3a65db8f01f8ee7f_68bec48f_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be singing here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_4eda0c4a_surprise.wav", "emotion": "surprise", "sentence": "She fell down and started laughing.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5a063c2d844c7a00015e477d_4eda0c4a_joy.wav", "emotion": "joy", "sentence": "She fell down and started laughing.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "582474a8aac01b0001e45ef9_9c1cda4d_disgust.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "582474a8aac01b0001e45ef9_9c1cda4d_sadness.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "672941064eee8977e7916b37_3ee055d5_sadness.wav", "emotion": "sadness", "sentence": "I can't believe I have nothing else left.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "672941064eee8977e7916b37_3ee055d5_anger.wav", "emotion": "anger", "sentence": "I can't believe I have nothing else left.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_2d7ebe09_surprise.wav", "emotion": "surprise", "sentence": "He walked up and started hitting on her.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_2d7ebe09_disgust.wav", "emotion": "disgust", "sentence": "He walked up and started hitting on her.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "666f76b68b89442817be678a_40fd08e9_surprise.wav", "emotion": "surprise", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "666f76b68b89442817be678a_40fd08e9_fear.wav", "emotion": "fear", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "674d1412e0b30ad8c359b635_5446fbd7_disgust.wav", "emotion": "disgust", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "674d1412e0b30ad8c359b635_5446fbd7_sadness.wav", "emotion": "sadness", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_05f7ee9a_joy.wav", "emotion": "joy", "sentence": "She just blew her first bubble.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_05f7ee9a_surprise.wav", "emotion": "surprise", "sentence": "She just blew her first bubble.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_5446fbd7_sadness.wav", "emotion": "sadness", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "6419ae0434916e5dde92e2f2_5446fbd7_disgust.wav", "emotion": "disgust", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "677aa09e06098c948784a33c_c96143ed_fear.wav", "emotion": "fear", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
-{"filename": "677aa09e06098c948784a33c_c96143ed_anger.wav", "emotion": "anger", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
-{"filename": "661e7aea959de3433a8f255d_ea4d3e21_surprise.wav", "emotion": "surprise", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661e7aea959de3433a8f255d_ea4d3e21_fear.wav", "emotion": "fear", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66463e4efb99fba5a67a010a_d61a14e7_surprise.wav", "emotion": "surprise", "sentence": "I just lost my high score.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66463e4efb99fba5a67a010a_d61a14e7_sadness.wav", "emotion": "sadness", "sentence": "I just lost my high score.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_ea1f36c7_surprise.wav", "emotion": "surprise", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_ea1f36c7_fear.wav", "emotion": "fear", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_d1b4477e_surprise.wav", "emotion": "surprise", "sentence": "He just won first prize at his very first rodeo.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_d1b4477e_joy.wav", "emotion": "joy", "sentence": "He just won first prize at his very first rodeo.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5d09036d59d0de0001310b4e_e20a4ee9_surprise.wav", "emotion": "surprise", "sentence": "He stood uncomfortably close.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "5d09036d59d0de0001310b4e_e20a4ee9_disgust.wav", "emotion": "disgust", "sentence": "He stood uncomfortably close.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_9be88a8f_disgust.wav", "emotion": "disgust", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_9be88a8f_sadness.wav", "emotion": "sadness", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "668758de3a65db8f01f8ee7f_c6e045c8_fear.wav", "emotion": "fear", "sentence": "You're going into those woods by yourself.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "668758de3a65db8f01f8ee7f_c6e045c8_surprise.wav", "emotion": "surprise", "sentence": "You're going into those woods by yourself.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_26fc7965_surprise.wav", "emotion": "surprise", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_26fc7965_fear.wav", "emotion": "fear", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "655f8edb8b128e01321fbf88_890bee09_sadness.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "655f8edb8b128e01321fbf88_890bee09_surprise.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_fae6c996_anger.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_fae6c996_surprise.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_278eece5_neutral.wav", "emotion": "neutral", "sentence": "I just found out I can buy this rifle online.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_278eece5_surprise.wav", "emotion": "surprise", "sentence": "I just found out I can buy this rifle online.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_406cf59f_joy.wav", "emotion": "joy", "sentence": "I just kissed my personal trainer at the gym.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_406cf59f_surprise.wav", "emotion": "surprise", "sentence": "I just kissed my personal trainer at the gym.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_db67df65_fear.wav", "emotion": "fear", "sentence": "She walked alone into the dimly lit convenience store.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_db67df65_sadness.wav", "emotion": "sadness", "sentence": "She walked alone into the dimly lit convenience store.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "661e7aea959de3433a8f255d_6c7e68ba_sadness.wav", "emotion": "sadness", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661e7aea959de3433a8f255d_6c7e68ba_surprise.wav", "emotion": "surprise", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_cde4a4dd_joy.wav", "emotion": "joy", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_cde4a4dd_surprise.wav", "emotion": "surprise", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_198f3011_sadness.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_198f3011_surprise.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_0fc75602_sadness.wav", "emotion": "sadness", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66c87644a4f4b16d885298dc_0fc75602_fear.wav", "emotion": "fear", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ee10a2fd_surprise.wav", "emotion": "surprise", "sentence": "She had never worn anything so constricting before.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ee10a2fd_fear.wav", "emotion": "fear", "sentence": "She had never worn anything so constricting before.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672941064eee8977e7916b37_1197329e_surprise.wav", "emotion": "surprise", "sentence": "She just found out she wasn't alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672941064eee8977e7916b37_1197329e_fear.wav", "emotion": "fear", "sentence": "She just found out she wasn't alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_8cbee814_surprise.wav", "emotion": "surprise", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_8cbee814_fear.wav", "emotion": "fear", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_0226896a_sadness.wav", "emotion": "sadness", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_0226896a_anger.wav", "emotion": "anger", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67abdd72c863ca5fbe8238cb_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67abdd72c863ca5fbe8238cb_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_19f7f11f_fear.wav", "emotion": "fear", "sentence": "I am about to run into this huge crowd of people.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_19f7f11f_surprise.wav", "emotion": "surprise", "sentence": "I am about to run into this huge crowd of people.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_ed7448ae_surprise.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5a063c2d844c7a00015e477d_ed7448ae_joy.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "66d72124d778efac4645d1d7_5446fbd7_sadness.wav", "emotion": "sadness", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "66d72124d778efac4645d1d7_5446fbd7_disgust.wav", "emotion": "disgust", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_7bdf2cd4_fear.wav", "emotion": "fear", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_7bdf2cd4_surprise.wav", "emotion": "surprise", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_f2b4276b_neutral.wav", "emotion": "neutral", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_f2b4276b_sadness.wav", "emotion": "sadness", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "661bd496ed5e403f399787c8_594d28dc_fear.wav", "emotion": "fear", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
-{"filename": "661bd496ed5e403f399787c8_594d28dc_neutral.wav", "emotion": "neutral", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
-{"filename": "667c86d3b9ca760b999914f3_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_6c7e68ba_sadness.wav", "emotion": "sadness", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_6c7e68ba_surprise.wav", "emotion": "surprise", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_671f5603_sadness.wav", "emotion": "sadness", "sentence": "I'm going up this mountain alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_671f5603_fear.wav", "emotion": "fear", "sentence": "I'm going up this mountain alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "664a9130e765f4b066ec179e_45bec536_sadness.wav", "emotion": "sadness", "sentence": "She hung up her wedding dress.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664a9130e765f4b066ec179e_45bec536_surprise.wav", "emotion": "surprise", "sentence": "She hung up her wedding dress.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6789b046961fcf908d886644_23410ba9_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be picking up this much of my life.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6789b046961fcf908d886644_23410ba9_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be picking up this much of my life.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6619cb1e30cb95691a6dd425_c146ebb3_surprise.wav", "emotion": "surprise", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6619cb1e30cb95691a6dd425_c146ebb3_fear.wav", "emotion": "fear", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "671e372ff616106156f72fd3_ec75c996_fear.wav", "emotion": "fear", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "671e372ff616106156f72fd3_ec75c996_sadness.wav", "emotion": "sadness", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "664f98c80beb5400a141ac91_e8c2252f_fear.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
-{"filename": "664f98c80beb5400a141ac91_e8c2252f_anger.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_e7546e45_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_e7546e45_surprise.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_c3a69aaf_sadness.wav", "emotion": "sadness", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_c3a69aaf_surprise.wav", "emotion": "surprise", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_4e057d7d_surprise.wav", "emotion": "surprise", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_4e057d7d_sadness.wav", "emotion": "sadness", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_2113b755_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_2113b755_neutral.wav", "emotion": "neutral", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_6e2e5ed8_fear.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_6e2e5ed8_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_f3c70ccf_sadness.wav", "emotion": "sadness", "sentence": "I've been listening to this hymn for years.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "582474a8aac01b0001e45ef9_f3c70ccf_neutral.wav", "emotion": "neutral", "sentence": "I've been listening to this hymn for years.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "67abdd72c863ca5fbe8238cb_5d83ff9f_anger.wav", "emotion": "anger", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
-{"filename": "67abdd72c863ca5fbe8238cb_5d83ff9f_fear.wav", "emotion": "fear", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
-{"filename": "67806e9d273c2547826d1d8b_fcafe5e5_fear.wav", "emotion": "fear", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67806e9d273c2547826d1d8b_fcafe5e5_sadness.wav", "emotion": "sadness", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5d09036d59d0de0001310b4e_30a5a1b1_surprise.wav", "emotion": "surprise", "sentence": "She ate something she shouldn't have.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5d09036d59d0de0001310b4e_30a5a1b1_fear.wav", "emotion": "fear", "sentence": "She ate something she shouldn't have.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_ed7448ae_joy.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_ed7448ae_surprise.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_95e02745_fear.wav", "emotion": "fear", "sentence": "You're going to crash your car.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_95e02745_surprise.wav", "emotion": "surprise", "sentence": "You're going to crash your car.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_0e3ef121_surprise.wav", "emotion": "surprise", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_0e3ef121_sadness.wav", "emotion": "sadness", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_630589fb_disgust.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_630589fb_sadness.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_aa7f4502_surprise.wav", "emotion": "surprise", "sentence": "You're really going through all those cloves of garlic.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_aa7f4502_sadness.wav", "emotion": "sadness", "sentence": "You're really going through all those cloves of garlic.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_2113b755_neutral.wav", "emotion": "neutral", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "662facfffb363cef00e404a8_2113b755_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_20cb0ac0_surprise.wav", "emotion": "surprise", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_20cb0ac0_anger.wav", "emotion": "anger", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_bfdef165_fear.wav", "emotion": "fear", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_bfdef165_sadness.wav", "emotion": "sadness", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67acb9892d24db4d61a856f5_1d26e784_surprise.wav", "emotion": "surprise", "sentence": "You are going into this ancient place alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_1d26e784_fear.wav", "emotion": "fear", "sentence": "You are going into this ancient place alone.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_ce2be7cb_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_ce2be7cb_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5d09036d59d0de0001310b4e_1b748b4b_surprise.wav", "emotion": "surprise", "sentence": "You are completely alone at this crowded party.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5d09036d59d0de0001310b4e_1b748b4b_fear.wav", "emotion": "fear", "sentence": "You are completely alone at this crowded party.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_3360b97d_sadness.wav", "emotion": "sadness", "sentence": "He had lost all his money at the roulette table.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_3360b97d_surprise.wav", "emotion": "surprise", "sentence": "He had lost all his money at the roulette table.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_fbe7148a_sadness.wav", "emotion": "sadness", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_fbe7148a_surprise.wav", "emotion": "surprise", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_5848668d_anger.wav", "emotion": "anger", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_5848668d_surprise.wav", "emotion": "surprise", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_ed7448ae_surprise.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5e4b4332e210130619b398c3_ed7448ae_joy.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "664cd1c6545aa0f362493dd9_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664cd1c6545aa0f362493dd9_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67abdd72c863ca5fbe8238cb_397ff4dd_surprise.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67abdd72c863ca5fbe8238cb_397ff4dd_fear.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "666f76b68b89442817be678a_7e3cada1_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be developing my own photographs again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "666f76b68b89442817be678a_7e3cada1_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be developing my own photographs again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_4c04ab98_fear.wav", "emotion": "fear", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_4c04ab98_surprise.wav", "emotion": "surprise", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_7d1c6d8f_neutral.wav", "emotion": "neutral", "sentence": "You flushed something down there.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_7d1c6d8f_surprise.wav", "emotion": "surprise", "sentence": "You flushed something down there.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67876285103f57f54f701beb_0bf6bf5c_fear.wav", "emotion": "fear", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67876285103f57f54f701beb_0bf6bf5c_sadness.wav", "emotion": "sadness", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_429c1cde_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be putting this old thing back up again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_429c1cde_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be putting this old thing back up again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_d585c456_surprise.wav", "emotion": "surprise", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_d585c456_fear.wav", "emotion": "fear", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67806e9d273c2547826d1d8b_030c313f_surprise.wav", "emotion": "surprise", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67806e9d273c2547826d1d8b_030c313f_sadness.wav", "emotion": "sadness", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "63ffcb367b500c516d0648a2_462143e1_surprise.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "63ffcb367b500c516d0648a2_462143e1_fear.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_c102bf1a_sadness.wav", "emotion": "sadness", "sentence": "I'm putting this stupid mascara back where I found it.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5dd72d2883e3096d755c0f14_c102bf1a_anger.wav", "emotion": "anger", "sentence": "I'm putting this stupid mascara back where I found it.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_3174083d_sadness.wav", "emotion": "sadness", "sentence": "You ruined another beautiful symphony.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "6419ae0434916e5dde92e2f2_3174083d_disgust.wav", "emotion": "disgust", "sentence": "You ruined another beautiful symphony.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "664a9130e765f4b066ec179e_f9533209_surprise.wav", "emotion": "surprise", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a9130e765f4b066ec179e_f9533209_fear.wav", "emotion": "fear", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672bbb444ab4546a33718004_c0df236b_surprise.wav", "emotion": "surprise", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672bbb444ab4546a33718004_c0df236b_sadness.wav", "emotion": "sadness", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_f14de307_joy.wav", "emotion": "joy", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_f14de307_surprise.wav", "emotion": "surprise", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_48581123_anger.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6699258fcd1cb9db035de794_48581123_sadness.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_6024af25_surprise.wav", "emotion": "surprise", "sentence": "She wore her highest stilettos despite being surrounded by uneven grass and balloons floating away.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_6024af25_fear.wav", "emotion": "fear", "sentence": "She wore her highest stilettos despite being surrounded by uneven grass and balloons floating away.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6699258fcd1cb9db035de794_b2eb25bd_surprise.wav", "emotion": "surprise", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6699258fcd1cb9db035de794_b2eb25bd_neutral.wav", "emotion": "neutral", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "5a063c2d844c7a00015e477d_ab8e2cc5_surprise.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_ab8e2cc5_fear.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a9130e765f4b066ec179e_7d1c6d8f_surprise.wav", "emotion": "surprise", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "664a9130e765f4b066ec179e_7d1c6d8f_neutral.wav", "emotion": "neutral", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "662facfffb363cef00e404a8_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "662facfffb363cef00e404a8_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_c77cb6ed_surprise.wav", "emotion": "surprise", "sentence": "I dropped the pass.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_c77cb6ed_sadness.wav", "emotion": "sadness", "sentence": "I dropped the pass.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "674ca794941ad6898969714b_890bee09_surprise.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "674ca794941ad6898969714b_890bee09_sadness.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_075af54e_fear.wav", "emotion": "fear", "sentence": "I just realized I left my passport at home.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6669f4d73f6ea3be1d2b7eae_075af54e_surprise.wav", "emotion": "surprise", "sentence": "I just realized I left my passport at home.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5b0df5bde9270900013bdf7f_d73d6e43_surprise.wav", "emotion": "surprise", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5b0df5bde9270900013bdf7f_d73d6e43_fear.wav", "emotion": "fear", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66c019586569ea36287bd523_528529ea_surprise.wav", "emotion": "surprise", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66c019586569ea36287bd523_528529ea_fear.wav", "emotion": "fear", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66439c275cd3cf1ee2426935_4f301c5b_surprise.wav", "emotion": "surprise", "sentence": "She heard footsteps coming from her cell.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66439c275cd3cf1ee2426935_4f301c5b_fear.wav", "emotion": "fear", "sentence": "She heard footsteps coming from her cell.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "665be0d7c160ab38d0795255_4ab30668_surprise.wav", "emotion": "surprise", "sentence": "You're actually going through with this and taking off your shoes!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "665be0d7c160ab38d0795255_4ab30668_joy.wav", "emotion": "joy", "sentence": "You're actually going through with this and taking off your shoes!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5ea196f089935b04d2ee69d9_5bd4e0cd_surprise.wav", "emotion": "surprise", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5ea196f089935b04d2ee69d9_5bd4e0cd_sadness.wav", "emotion": "sadness", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_81774650_surprise.wav", "emotion": "surprise", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_81774650_neutral.wav", "emotion": "neutral", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "677aa09e06098c948784a33c_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_21096146_neutral.wav", "emotion": "neutral", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_21096146_surprise.wav", "emotion": "surprise", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_be99fd79_anger.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_be99fd79_sadness.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_19b9c124_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_19b9c124_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_4c04ab98_surprise.wav", "emotion": "surprise", "sentence": "You are now operating this massive machine.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_4c04ab98_fear.wav", "emotion": "fear", "sentence": "You are now operating this massive machine.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a6bbe21031d20a2155427_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_36ea06af_sadness.wav", "emotion": "sadness", "sentence": "They are ruining their childhood.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67aca3ffca27d4b3908a7adc_36ea06af_anger.wav", "emotion": "anger", "sentence": "They are ruining their childhood.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "6691bc059b0182b0bdd7d682_462143e1_fear.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_462143e1_surprise.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_9bd526d3_surprise.wav", "emotion": "surprise", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_9bd526d3_fear.wav", "emotion": "fear", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_9dca4e3b_fear.wav", "emotion": "fear", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_9dca4e3b_surprise.wav", "emotion": "surprise", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_00e2698f_anger.wav", "emotion": "anger", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_00e2698f_surprise.wav", "emotion": "surprise", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "66ef1fe508a57ab4d42c952d_dc193dfd_anger.wav", "emotion": "anger", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_dc193dfd_sadness.wav", "emotion": "sadness", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_a300da8d_surprise.wav", "emotion": "surprise", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_a300da8d_fear.wav", "emotion": "fear", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_b70788d1_fear.wav", "emotion": "fear", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_b70788d1_sadness.wav", "emotion": "sadness", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_c4b02567_surprise.wav", "emotion": "surprise", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_c4b02567_fear.wav", "emotion": "fear", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_528529ea_surprise.wav", "emotion": "surprise", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_528529ea_fear.wav", "emotion": "fear", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_a93a0fd0_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_a93a0fd0_fear.wav", "emotion": "fear", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_f4259c46_fear.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this copy center.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_f4259c46_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this copy center.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ec30f90c_fear.wav", "emotion": "fear", "sentence": "She just saw her print job was going to cost $500.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ec30f90c_surprise.wav", "emotion": "surprise", "sentence": "She just saw her print job was going to cost $500.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_f2b4276b_neutral.wav", "emotion": "neutral", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_f2b4276b_sadness.wav", "emotion": "sadness", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_21096146_surprise.wav", "emotion": "surprise", "sentence": "I just found my old childhood TV.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_21096146_neutral.wav", "emotion": "neutral", "sentence": "I just found my old childhood TV.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_a6cda68d_fear.wav", "emotion": "fear", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_a6cda68d_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_1a193ade_sadness.wav", "emotion": "sadness", "sentence": "She found out she had been sleeping alone.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67876285103f57f54f701beb_1a193ade_surprise.wav", "emotion": "surprise", "sentence": "She found out she had been sleeping alone.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_645d382a_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6600d4ab3d166502ff03c3aa_645d382a_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_83a169f2_surprise.wav", "emotion": "surprise", "sentence": "He just told me he makes $100k per year.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "5a063c2d844c7a00015e477d_83a169f2_anger.wav", "emotion": "anger", "sentence": "He just told me he makes $100k per year.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672268205351c30413c9837e_8f4e8c06_surprise.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672268205351c30413c9837e_8f4e8c06_anger.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67876285103f57f54f701beb_b469ae9d_fear.wav", "emotion": "fear", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_b469ae9d_surprise.wav", "emotion": "surprise", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_552a6412_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_552a6412_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_d80b7cee_sadness.wav", "emotion": "sadness", "sentence": "I just tripped and fell onto my butt.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_d80b7cee_surprise.wav", "emotion": "surprise", "sentence": "I just tripped and fell onto my butt.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_b67adb64_surprise.wav", "emotion": "surprise", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "6419ae0434916e5dde92e2f2_b67adb64_joy.wav", "emotion": "joy", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "66439c275cd3cf1ee2426935_063d0542_sadness.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66439c275cd3cf1ee2426935_063d0542_surprise.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6745731e75a88802a56be3ef_063d0542_sadness.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6745731e75a88802a56be3ef_063d0542_surprise.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_5848668d_anger.wav", "emotion": "anger", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_5848668d_surprise.wav", "emotion": "surprise", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "666f76b68b89442817be678a_fd193ceb_fear.wav", "emotion": "fear", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
-{"filename": "666f76b68b89442817be678a_fd193ceb_anger.wav", "emotion": "anger", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_80a36bd8_surprise.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_80a36bd8_anger.wav", "emotion": "anger", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "664cf2037353bb98801436b5_04d95efa_surprise.wav", "emotion": "surprise", "sentence": "She just got assigned as lead reporter for tonight's breaking story.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "664cf2037353bb98801436b5_04d95efa_neutral.wav", "emotion": "neutral", "sentence": "She just got assigned as lead reporter for tonight's breaking story.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "666f76b68b89442817be678a_adebc747_anger.wav", "emotion": "anger", "sentence": "I am so sick of these stupid rules.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "666f76b68b89442817be678a_adebc747_sadness.wav", "emotion": "sadness", "sentence": "I am so sick of these stupid rules.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "5ea196f089935b04d2ee69d9_e79b6f74_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "5ea196f089935b04d2ee69d9_e79b6f74_disgust.wav", "emotion": "disgust", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "582474a8aac01b0001e45ef9_a07bc5eb_sadness.wav", "emotion": "sadness", "sentence": "You're going to have to get used to taking baths alone now.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "582474a8aac01b0001e45ef9_a07bc5eb_neutral.wav", "emotion": "neutral", "sentence": "You're going to have to get used to taking baths alone now.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "66439c275cd3cf1ee2426935_e871f202_surprise.wav", "emotion": "surprise", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66439c275cd3cf1ee2426935_e871f202_sadness.wav", "emotion": "sadness", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5ea196f089935b04d2ee69d9_fdf1900e_fear.wav", "emotion": "fear", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5ea196f089935b04d2ee69d9_fdf1900e_surprise.wav", "emotion": "surprise", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_738dde1d_fear.wav", "emotion": "fear", "sentence": "I just saw my crush walk into this sketchy underground bowling alley.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_738dde1d_surprise.wav", "emotion": "surprise", "sentence": "I just saw my crush walk into this sketchy underground bowling alley.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_bfdef165_fear.wav", "emotion": "fear", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_bfdef165_sadness.wav", "emotion": "sadness", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "582474a8aac01b0001e45ef9_bab0d57f_sadness.wav", "emotion": "sadness", "sentence": "You just lost your favorite mug.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_bab0d57f_surprise.wav", "emotion": "surprise", "sentence": "You just lost your favorite mug.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_7bdf2cd4_fear.wav", "emotion": "fear", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_7bdf2cd4_surprise.wav", "emotion": "surprise", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_cb7bef54_sadness.wav", "emotion": "sadness", "sentence": "I am so tired of this.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5a063c2d844c7a00015e477d_cb7bef54_anger.wav", "emotion": "anger", "sentence": "I am so tired of this.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67806e9d273c2547826d1d8b_9dca4e3b_fear.wav", "emotion": "fear", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67806e9d273c2547826d1d8b_9dca4e3b_surprise.wav", "emotion": "surprise", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_0a40c75d_anger.wav", "emotion": "anger", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_0a40c75d_sadness.wav", "emotion": "sadness", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "664a9130e765f4b066ec179e_26fc7965_surprise.wav", "emotion": "surprise", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a9130e765f4b066ec179e_26fc7965_fear.wav", "emotion": "fear", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "63ffcb367b500c516d0648a2_eacff021_fear.wav", "emotion": "fear", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "63ffcb367b500c516d0648a2_eacff021_sadness.wav", "emotion": "sadness", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "671e372ff616106156f72fd3_e189c19e_surprise.wav", "emotion": "surprise", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "671e372ff616106156f72fd3_e189c19e_disgust.wav", "emotion": "disgust", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "66439c275cd3cf1ee2426935_5b26beac_neutral.wav", "emotion": "neutral", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66439c275cd3cf1ee2426935_5b26beac_surprise.wav", "emotion": "surprise", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_e07b4fe6_sadness.wav", "emotion": "sadness", "sentence": "You're really going down there.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_e07b4fe6_surprise.wav", "emotion": "surprise", "sentence": "You're really going down there.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_a300da8d_fear.wav", "emotion": "fear", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_a300da8d_surprise.wav", "emotion": "surprise", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_c67e8d8e_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67acae4d2601703808e7e666_c67e8d8e_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5dd72d2883e3096d755c0f14_239c3076_sadness.wav", "emotion": "sadness", "sentence": "You just found out you are making less than your coworker.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_239c3076_surprise.wav", "emotion": "surprise", "sentence": "You just found out you are making less than your coworker.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_4a025bc4_surprise.wav", "emotion": "surprise", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_4a025bc4_disgust.wav", "emotion": "disgust", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "67876285103f57f54f701beb_b0628296_fear.wav", "emotion": "fear", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_b0628296_surprise.wav", "emotion": "surprise", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_8f4e8c06_surprise.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
-{"filename": "582474a8aac01b0001e45ef9_8f4e8c06_anger.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
-{"filename": "6732de5c32981eeab9c67bd1_c6f0cf65_sadness.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_c6f0cf65_surprise.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_6e2e5ed8_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_6e2e5ed8_fear.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_594d28dc_fear.wav", "emotion": "fear", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_594d28dc_neutral.wav", "emotion": "neutral", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
-{"filename": "672268205351c30413c9837e_a7cedb78_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this very same lobby.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672268205351c30413c9837e_a7cedb78_fear.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this very same lobby.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6685bda9fe63421c0f632414_645d382a_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6685bda9fe63421c0f632414_645d382a_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_9615b184_surprise.wav", "emotion": "surprise", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "604bd44cb5668ba12cc9376e_9615b184_sadness.wav", "emotion": "sadness", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672941064eee8977e7916b37_8ac362d6_surprise.wav", "emotion": "surprise", "sentence": "She just got her friend completely soaked.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "672941064eee8977e7916b37_8ac362d6_joy.wav", "emotion": "joy", "sentence": "She just got her friend completely soaked.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_cd8c8b91_sadness.wav", "emotion": "sadness", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_cd8c8b91_surprise.wav", "emotion": "surprise", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_88aed7cd_sadness.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67abdd72c863ca5fbe8238cb_88aed7cd_fear.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_bfdef165_sadness.wav", "emotion": "sadness", "sentence": "I'm going back down there alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_bfdef165_fear.wav", "emotion": "fear", "sentence": "I'm going back down there alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "604bd44cb5668ba12cc9376e_2456c9a6_sadness.wav", "emotion": "sadness", "sentence": "You're really drinking just plain old tapwater?", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_2456c9a6_surprise.wav", "emotion": "surprise", "sentence": "You're really drinking just plain old tapwater?", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_ff00d689_fear.wav", "emotion": "fear", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_ff00d689_surprise.wav", "emotion": "surprise", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_3ea21e2d_surprise.wav", "emotion": "surprise", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6712795a5e34ccb89d7fd40d_3ea21e2d_fear.wav", "emotion": "fear", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_8cd307fe_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_8cd307fe_fear.wav", "emotion": "fear", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ed5f55c7_fear.wav", "emotion": "fear", "sentence": "She dove into the deep end of the empty swimming pool.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ed5f55c7_surprise.wav", "emotion": "surprise", "sentence": "She dove into the deep end of the empty swimming pool.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "666f76b68b89442817be678a_e46f81c9_surprise.wav", "emotion": "surprise", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "666f76b68b89442817be678a_e46f81c9_neutral.wav", "emotion": "neutral", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_209d5928_sadness.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_209d5928_anger.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5a063c2d844c7a00015e477d_64809ec4_sadness.wav", "emotion": "sadness", "sentence": "I'm running out of space.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5a063c2d844c7a00015e477d_64809ec4_fear.wav", "emotion": "fear", "sentence": "I'm running out of space.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_131920dd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_131920dd_sadness.wav", "emotion": "sadness", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67acb9892d24db4d61a856f5_d1405720_surprise.wav", "emotion": "surprise", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_d1405720_fear.wav", "emotion": "fear", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_c399918a_surprise.wav", "emotion": "surprise", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_c399918a_sadness.wav", "emotion": "sadness", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6712795a5e34ccb89d7fd40d_041712e6_joy.wav", "emotion": "joy", "sentence": "I finally got sober.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "6712795a5e34ccb89d7fd40d_041712e6_sadness.wav", "emotion": "sadness", "sentence": "I finally got sober.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "667c86d3b9ca760b999914f3_e8c2252f_fear.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
-{"filename": "667c86d3b9ca760b999914f3_e8c2252f_anger.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_5dafd801_fear.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_5dafd801_surprise.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_add4afcd_anger.wav", "emotion": "anger", "sentence": "I just got kicked out of my own game.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67aca3ffca27d4b3908a7adc_add4afcd_sadness.wav", "emotion": "sadness", "sentence": "I just got kicked out of my own game.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66c87644a4f4b16d885298dc_297cb01d_fear.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66c87644a4f4b16d885298dc_297cb01d_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "662facfffb363cef00e404a8_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664a6bbe21031d20a2155427_397ff4dd_surprise.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a6bbe21031d20a2155427_397ff4dd_fear.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_72eb8a3a_fear.wav", "emotion": "fear", "sentence": "You're going near those murky waters.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_72eb8a3a_surprise.wav", "emotion": "surprise", "sentence": "You're going near those murky waters.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_55d9ab65_fear.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_55d9ab65_surprise.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6789b046961fcf908d886644_82cbee14_sadness.wav", "emotion": "sadness", "sentence": "I've been writing this novel for years and I still haven't finished.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "6789b046961fcf908d886644_82cbee14_neutral.wav", "emotion": "neutral", "sentence": "I've been writing this novel for years and I still haven't finished.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_010de644_surprise.wav", "emotion": "surprise", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_010de644_anger.wav", "emotion": "anger", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "582474a8aac01b0001e45ef9_b19b5b6c_surprise.wav", "emotion": "surprise", "sentence": "I just made my very first dunk.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "582474a8aac01b0001e45ef9_b19b5b6c_joy.wav", "emotion": "joy", "sentence": "I just made my very first dunk.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "6419ae0434916e5dde92e2f2_026b30f8_surprise.wav", "emotion": "surprise", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_026b30f8_sadness.wav", "emotion": "sadness", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_65c288b3_neutral.wav", "emotion": "neutral", "sentence": "She had never walked through this part of the field before.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_65c288b3_surprise.wav", "emotion": "surprise", "sentence": "She had never walked through this part of the field before.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "666f76b68b89442817be678a_ec3ee8d6_fear.wav", "emotion": "fear", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "666f76b68b89442817be678a_ec3ee8d6_surprise.wav", "emotion": "surprise", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_a7e07b6e_surprise.wav", "emotion": "surprise", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_a7e07b6e_fear.wav", "emotion": "fear", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_041712e6_sadness.wav", "emotion": "sadness", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "67acb9892d24db4d61a856f5_041712e6_joy.wav", "emotion": "joy", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "668758de3a65db8f01f8ee7f_05d92332_surprise.wav", "emotion": "surprise", "sentence": "She mentioned her faith while getting a haircut.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "668758de3a65db8f01f8ee7f_05d92332_neutral.wav", "emotion": "neutral", "sentence": "She mentioned her faith while getting a haircut.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6712795a5e34ccb89d7fd40d_e79b6f74_disgust.wav", "emotion": "disgust", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_e79b6f74_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_74a0d11d_surprise.wav", "emotion": "surprise", "sentence": "They were having an affair.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "5a063c2d844c7a00015e477d_74a0d11d_neutral.wav", "emotion": "neutral", "sentence": "They were having an affair.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "67acae4d2601703808e7e666_61056896_anger.wav", "emotion": "anger", "sentence": "You're surrounded.", "expected_emotions": ["anger", "fear"]}
-{"filename": "67acae4d2601703808e7e666_61056896_fear.wav", "emotion": "fear", "sentence": "You're surrounded.", "expected_emotions": ["anger", "fear"]}
-{"filename": "67abdd72c863ca5fbe8238cb_b3f7edf3_joy.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "67abdd72c863ca5fbe8238cb_b3f7edf3_sadness.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_d5404fc9_surprise.wav", "emotion": "surprise", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_d5404fc9_sadness.wav", "emotion": "sadness", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_48dd141a_anger.wav", "emotion": "anger", "sentence": "You're going to have to get out of here now.", "expected_emotions": ["anger", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_48dd141a_fear.wav", "emotion": "fear", "sentence": "You're going to have to get out of here now.", "expected_emotions": ["anger", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_397ff4dd_fear.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_397ff4dd_surprise.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_2e5a2c83_sadness.wav", "emotion": "sadness", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_2e5a2c83_surprise.wav", "emotion": "surprise", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_5d83ff9f_fear.wav", "emotion": "fear", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["fear", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_5d83ff9f_anger.wav", "emotion": "anger", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["fear", "anger"]}
-{"filename": "5a063c2d844c7a00015e477d_7c45c40e_surprise.wav", "emotion": "surprise", "sentence": "You are standing alone at this beautiful mountaintop.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_7c45c40e_sadness.wav", "emotion": "sadness", "sentence": "You are standing alone at this beautiful mountaintop.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6619cb1e30cb95691a6dd425_5260adbc_fear.wav", "emotion": "fear", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_5260adbc_surprise.wav", "emotion": "surprise", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_ec75c996_fear.wav", "emotion": "fear", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_ec75c996_sadness.wav", "emotion": "sadness", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_a7c5ffec_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_a7c5ffec_anger.wav", "emotion": "anger", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5e4b4332e210130619b398c3_7d1c6d8f_surprise.wav", "emotion": "surprise", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "5e4b4332e210130619b398c3_7d1c6d8f_neutral.wav", "emotion": "neutral", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "661bd496ed5e403f399787c8_d794c82b_fear.wav", "emotion": "fear", "sentence": "You've really done something this time.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_d794c82b_surprise.wav", "emotion": "surprise", "sentence": "You've really done something this time.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_93ef79a9_neutral.wav", "emotion": "neutral", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_93ef79a9_surprise.wav", "emotion": "surprise", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66ef1fe508a57ab4d42c952d_030c313f_surprise.wav", "emotion": "surprise", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_030c313f_sadness.wav", "emotion": "sadness", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "63ffcb367b500c516d0648a2_fae6c996_surprise.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "63ffcb367b500c516d0648a2_fae6c996_anger.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_45bec536_surprise.wav", "emotion": "surprise", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_45bec536_sadness.wav", "emotion": "sadness", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_8dafb30d_fear.wav", "emotion": "fear", "sentence": "You're going deeper into these woods.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_8dafb30d_surprise.wav", "emotion": "surprise", "sentence": "You're going deeper into these woods.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a9130e765f4b066ec179e_026b30f8_sadness.wav", "emotion": "sadness", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664a9130e765f4b066ec179e_026b30f8_surprise.wav", "emotion": "surprise", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "674ca794941ad6898969714b_630589fb_sadness.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "674ca794941ad6898969714b_630589fb_disgust.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "672268205351c30413c9837e_b0628296_surprise.wav", "emotion": "surprise", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672268205351c30413c9837e_b0628296_fear.wav", "emotion": "fear", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5d09036d59d0de0001310b4e_49945bef_disgust.wav", "emotion": "disgust", "sentence": "She showed her belly button ring.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_49945bef_surprise.wav", "emotion": "surprise", "sentence": "She showed her belly button ring.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "672268205351c30413c9837e_ea69aeb3_fear.wav", "emotion": "fear", "sentence": "You're really going through all this trouble just for your faith.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_ea69aeb3_surprise.wav", "emotion": "surprise", "sentence": "You're really going through all this trouble just for your faith.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_29db99b2_surprise.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67876285103f57f54f701beb_29db99b2_fear.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "604bd44cb5668ba12cc9376e_bd342048_fear.wav", "emotion": "fear", "sentence": "She saw him standing alone at dusk.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_bd342048_surprise.wav", "emotion": "surprise", "sentence": "She saw him standing alone at dusk.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "674ca794941ad6898969714b_ae399ff1_surprise.wav", "emotion": "surprise", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "674ca794941ad6898969714b_ae399ff1_fear.wav", "emotion": "fear", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_ab8e2cc5_surprise.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "677aa09e06098c948784a33c_ab8e2cc5_fear.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661bd496ed5e403f399787c8_eb5723a9_sadness.wav", "emotion": "sadness", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_eb5723a9_surprise.wav", "emotion": "surprise", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_28094ddc_fear.wav", "emotion": "fear", "sentence": "He was not going anywhere until he told them what they wanted.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_28094ddc_surprise.wav", "emotion": "surprise", "sentence": "He was not going anywhere until he told them what they wanted.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_f9e443f1_sadness.wav", "emotion": "sadness", "sentence": "You're going to have trouble filling out this entire thing.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_f9e443f1_surprise.wav", "emotion": "surprise", "sentence": "You're going to have trouble filling out this entire thing.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66439c275cd3cf1ee2426935_22d8da52_anger.wav", "emotion": "anger", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
-{"filename": "66439c275cd3cf1ee2426935_22d8da52_surprise.wav", "emotion": "surprise", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_ab8e2cc5_fear.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_ab8e2cc5_surprise.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_91dcc346_fear.wav", "emotion": "fear", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_91dcc346_sadness.wav", "emotion": "sadness", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "668758de3a65db8f01f8ee7f_bb8d2385_sadness.wav", "emotion": "sadness", "sentence": "I can't believe I've ended up here again.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "668758de3a65db8f01f8ee7f_bb8d2385_disgust.wav", "emotion": "disgust", "sentence": "I can't believe I've ended up here again.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "67876285103f57f54f701beb_10969ae0_fear.wav", "emotion": "fear", "sentence": "She just flushed something down there.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_10969ae0_surprise.wav", "emotion": "surprise", "sentence": "She just flushed something down there.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_b70f024b_surprise.wav", "emotion": "surprise", "sentence": "She didn't see him fall from scaffolding.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_b70f024b_fear.wav", "emotion": "fear", "sentence": "She didn't see him fall from scaffolding.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664cf2037353bb98801436b5_e5fa388b_anger.wav", "emotion": "anger", "sentence": "She has been lying there for hours.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "664cf2037353bb98801436b5_e5fa388b_sadness.wav", "emotion": "sadness", "sentence": "She has been lying there for hours.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "672941064eee8977e7916b37_b0733604_sadness.wav", "emotion": "sadness", "sentence": "She had eaten all of his favorite pastries.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "672941064eee8977e7916b37_b0733604_anger.wav", "emotion": "anger", "sentence": "She had eaten all of his favorite pastries.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67806e9d273c2547826d1d8b_ef24be6d_surprise.wav", "emotion": "surprise", "sentence": "I just found out we have recess today!", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "67806e9d273c2547826d1d8b_ef24be6d_neutral.wav", "emotion": "neutral", "sentence": "I just found out we have recess today!", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "67aca3ffca27d4b3908a7adc_bac4a4a6_disgust.wav", "emotion": "disgust", "sentence": "She ate her fish straight from the bones.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_bac4a4a6_surprise.wav", "emotion": "surprise", "sentence": "She ate her fish straight from the bones.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_77a6efc8_anger.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_77a6efc8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "671e372ff616106156f72fd3_40fd08e9_fear.wav", "emotion": "fear", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "671e372ff616106156f72fd3_40fd08e9_surprise.wav", "emotion": "surprise", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_8cd307fe_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "582474a8aac01b0001e45ef9_8cd307fe_fear.wav", "emotion": "fear", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_c3a69aaf_surprise.wav", "emotion": "surprise", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_c3a69aaf_sadness.wav", "emotion": "sadness", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_88aed7cd_fear.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_88aed7cd_sadness.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67876285103f57f54f701beb_297cb01d_fear.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_297cb01d_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "668758de3a65db8f01f8ee7f_b99164e8_surprise.wav", "emotion": "surprise", "sentence": "You are about to be summoned.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "668758de3a65db8f01f8ee7f_b99164e8_fear.wav", "emotion": "fear", "sentence": "You are about to be summoned.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_cb7bef54_anger.wav", "emotion": "anger", "sentence": "I am so tired of this.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_cb7bef54_sadness.wav", "emotion": "sadness", "sentence": "I am so tired of this.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6619cb1e30cb95691a6dd425_5bd4e0cd_surprise.wav", "emotion": "surprise", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6619cb1e30cb95691a6dd425_5bd4e0cd_sadness.wav", "emotion": "sadness", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "677aa09e06098c948784a33c_b67adb64_surprise.wav", "emotion": "surprise", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "677aa09e06098c948784a33c_b67adb64_joy.wav", "emotion": "joy", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "664f98c80beb5400a141ac91_2113b755_neutral.wav", "emotion": "neutral", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_2113b755_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_67c29c8e_joy.wav", "emotion": "joy", "sentence": "I never expected you would be sitting next me at this performance.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_67c29c8e_surprise.wav", "emotion": "surprise", "sentence": "I never expected you would be sitting next me at this performance.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "67876285103f57f54f701beb_fb5dae16_fear.wav", "emotion": "fear", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_fb5dae16_surprise.wav", "emotion": "surprise", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acb9892d24db4d61a856f5_3fdbf166_fear.wav", "emotion": "fear", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
-{"filename": "67acb9892d24db4d61a856f5_3fdbf166_anger.wav", "emotion": "anger", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
-{"filename": "672941064eee8977e7916b37_887ccc07_surprise.wav", "emotion": "surprise", "sentence": "You've finally hung those old curtains.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672941064eee8977e7916b37_887ccc07_sadness.wav", "emotion": "sadness", "sentence": "You've finally hung those old curtains.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_25968f77_joy.wav", "emotion": "joy", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_25968f77_surprise.wav", "emotion": "surprise", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_31dad80b_fear.wav", "emotion": "fear", "sentence": "He's running low.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_31dad80b_surprise.wav", "emotion": "surprise", "sentence": "He's running low.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_19b9c124_sadness.wav", "emotion": "sadness", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_19b9c124_surprise.wav", "emotion": "surprise", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66463e4efb99fba5a67a010a_1bf5a907_fear.wav", "emotion": "fear", "sentence": "She jumped out of her seat as he announced his candidacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66463e4efb99fba5a67a010a_1bf5a907_surprise.wav", "emotion": "surprise", "sentence": "She jumped out of her seat as he announced his candidacy.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_35000989_sadness.wav", "emotion": "sadness", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_35000989_anger.wav", "emotion": "anger", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_40fd08e9_surprise.wav", "emotion": "surprise", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_40fd08e9_fear.wav", "emotion": "fear", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "674ca794941ad6898969714b_9a6ed6da_surprise.wav", "emotion": "surprise", "sentence": "You're actually seeing me.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "674ca794941ad6898969714b_9a6ed6da_fear.wav", "emotion": "fear", "sentence": "You're actually seeing me.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "604bd44cb5668ba12cc9376e_aaee06c6_fear.wav", "emotion": "fear", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "604bd44cb5668ba12cc9376e_aaee06c6_sadness.wav", "emotion": "sadness", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "674ca794941ad6898969714b_fae6c996_surprise.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "674ca794941ad6898969714b_fae6c996_anger.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "677aa09e06098c948784a33c_ed7448ae_joy.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_ed7448ae_surprise.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_77c92810_fear.wav", "emotion": "fear", "sentence": "I just saw my ex-partner walk into this room.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_77c92810_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex-partner walk into this room.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_55d9ab65_fear.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_55d9ab65_surprise.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5b0df5bde9270900013bdf7f_602c826c_fear.wav", "emotion": "fear", "sentence": "You're standing too close.", "expected_emotions": ["fear", "disgust"]}
-{"filename": "5b0df5bde9270900013bdf7f_602c826c_disgust.wav", "emotion": "disgust", "sentence": "You're standing too close.", "expected_emotions": ["fear", "disgust"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_77a6efc8_anger.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_77a6efc8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67876285103f57f54f701beb_c0df236b_surprise.wav", "emotion": "surprise", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67876285103f57f54f701beb_c0df236b_sadness.wav", "emotion": "sadness", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664a9130e765f4b066ec179e_6c14a5a5_fear.wav", "emotion": "fear", "sentence": "She walked alone through the dark corridors of her new barracks.", "expected_emotions": ["fear", "neutral"]}
-{"filename": "664a9130e765f4b066ec179e_6c14a5a5_neutral.wav", "emotion": "neutral", "sentence": "She walked alone through the dark corridors of her new barracks.", "expected_emotions": ["fear", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_c96143ed_fear.wav", "emotion": "fear", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_c96143ed_anger.wav", "emotion": "anger", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
-{"filename": "665be0d7c160ab38d0795255_384c09b5_neutral.wav", "emotion": "neutral", "sentence": "You just made your first three-pointer.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_384c09b5_surprise.wav", "emotion": "surprise", "sentence": "You just made your first three-pointer.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_77a6efc8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "6732de5c32981eeab9c67bd1_77a6efc8_anger.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "582474a8aac01b0001e45ef9_0fc75602_sadness.wav", "emotion": "sadness", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "582474a8aac01b0001e45ef9_0fc75602_fear.wav", "emotion": "fear", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67876285103f57f54f701beb_c0c720e8_fear.wav", "emotion": "fear", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67876285103f57f54f701beb_c0c720e8_surprise.wav", "emotion": "surprise", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5a063c2d844c7a00015e477d_d5404fc9_surprise.wav", "emotion": "surprise", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5a063c2d844c7a00015e477d_d5404fc9_sadness.wav", "emotion": "sadness", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6600d4ab3d166502ff03c3aa_b6fe0734_surprise.wav", "emotion": "surprise", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6600d4ab3d166502ff03c3aa_b6fe0734_fear.wav", "emotion": "fear", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_7414ad88_fear.wav", "emotion": "fear", "sentence": "You're going too close to fast moving water.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_7414ad88_surprise.wav", "emotion": "surprise", "sentence": "You're going too close to fast moving water.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_d9f22bd6_joy.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "63ffcb367b500c516d0648a2_d9f22bd6_fear.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "6789b046961fcf908d886644_240dbeae_fear.wav", "emotion": "fear", "sentence": "She found something stuck between her teeth.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6789b046961fcf908d886644_240dbeae_surprise.wav", "emotion": "surprise", "sentence": "She found something stuck between her teeth.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_1e8451af_neutral.wav", "emotion": "neutral", "sentence": "You're taking another class today.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_1e8451af_surprise.wav", "emotion": "surprise", "sentence": "You're taking another class today.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_9bd526d3_surprise.wav", "emotion": "surprise", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6732de5c32981eeab9c67bd1_9bd526d3_fear.wav", "emotion": "fear", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6685bda9fe63421c0f632414_1ffe7629_fear.wav", "emotion": "fear", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6685bda9fe63421c0f632414_1ffe7629_surprise.wav", "emotion": "surprise", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_c3a69aaf_sadness.wav", "emotion": "sadness", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_c3a69aaf_surprise.wav", "emotion": "surprise", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_79eb3f50_surprise.wav", "emotion": "surprise", "sentence": "You're going to be late for your exam!", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_79eb3f50_fear.wav", "emotion": "fear", "sentence": "You're going to be late for your exam!", "expected_emotions": ["surprise", "fear"]}
-{"filename": "662facfffb363cef00e404a8_198f3011_surprise.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "662facfffb363cef00e404a8_198f3011_sadness.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "666f76b68b89442817be678a_e189c19e_surprise.wav", "emotion": "surprise", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "666f76b68b89442817be678a_e189c19e_disgust.wav", "emotion": "disgust", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "6419ae0434916e5dde92e2f2_63db2679_sadness.wav", "emotion": "sadness", "sentence": "You're telling me I have to pay full price?", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_63db2679_surprise.wav", "emotion": "surprise", "sentence": "You're telling me I have to pay full price?", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_f26bfaa5_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_f26bfaa5_fear.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "666f76b68b89442817be678a_c83a3e56_neutral.wav", "emotion": "neutral", "sentence": "I am flying alone.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "666f76b68b89442817be678a_c83a3e56_sadness.wav", "emotion": "sadness", "sentence": "I am flying alone.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "664cf2037353bb98801436b5_88d0d503_anger.wav", "emotion": "anger", "sentence": "She slammed her hand down on the table.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_88d0d503_surprise.wav", "emotion": "surprise", "sentence": "She slammed her hand down on the table.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_ed1652ca_surprise.wav", "emotion": "surprise", "sentence": "She was running down from her room.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67aca3ffca27d4b3908a7adc_ed1652ca_fear.wav", "emotion": "fear", "sentence": "She was running down from her room.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "582474a8aac01b0001e45ef9_2afb09ee_neutral.wav", "emotion": "neutral", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "582474a8aac01b0001e45ef9_2afb09ee_sadness.wav", "emotion": "sadness", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_2c09ea6f_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_2c09ea6f_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_d9f22bd6_joy.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "6691bc059b0182b0bdd7d682_d9f22bd6_fear.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_715d7217_fear.wav", "emotion": "fear", "sentence": "She just did an unexpected backflip.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acb9892d24db4d61a856f5_715d7217_surprise.wav", "emotion": "surprise", "sentence": "She just did an unexpected backflip.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66439c275cd3cf1ee2426935_11900cc4_surprise.wav", "emotion": "surprise", "sentence": "I have never dug this deep before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66439c275cd3cf1ee2426935_11900cc4_neutral.wav", "emotion": "neutral", "sentence": "I have never dug this deep before.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66d72124d778efac4645d1d7_66788940_fear.wav", "emotion": "fear", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_66788940_surprise.wav", "emotion": "surprise", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_be319ba8_surprise.wav", "emotion": "surprise", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_be319ba8_sadness.wav", "emotion": "sadness", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_9c1cda4d_disgust.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "6691bc059b0182b0bdd7d682_9c1cda4d_sadness.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "667c86d3b9ca760b999914f3_b1f4c50b_fear.wav", "emotion": "fear", "sentence": "You're going outside alone at night?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_b1f4c50b_surprise.wav", "emotion": "surprise", "sentence": "You're going outside alone at night?", "expected_emotions": ["fear", "surprise"]}
-{"filename": "675ef1840636ec90d906ea28_5b58dbed_surprise.wav", "emotion": "surprise", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "675ef1840636ec90d906ea28_5b58dbed_fear.wav", "emotion": "fear", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "671e372ff616106156f72fd3_c2679c77_fear.wav", "emotion": "fear", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "671e372ff616106156f72fd3_c2679c77_surprise.wav", "emotion": "surprise", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_fbe7148a_sadness.wav", "emotion": "sadness", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_fbe7148a_surprise.wav", "emotion": "surprise", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_48581123_sadness.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "677aa09e06098c948784a33c_48581123_anger.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "664cf2037353bb98801436b5_197b22b4_fear.wav", "emotion": "fear", "sentence": "I just saw something big moving under water.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_197b22b4_surprise.wav", "emotion": "surprise", "sentence": "I just saw something big moving under water.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664a6bbe21031d20a2155427_54345e2f_surprise.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a6bbe21031d20a2155427_54345e2f_fear.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_cc9c3b5d_surprise.wav", "emotion": "surprise", "sentence": "You're really going for a hike wearing those sandals.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_cc9c3b5d_fear.wav", "emotion": "fear", "sentence": "You're really going for a hike wearing those sandals.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_9598b70a_fear.wav", "emotion": "fear", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_9598b70a_surprise.wav", "emotion": "surprise", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_c4b02567_fear.wav", "emotion": "fear", "sentence": "I am going for skydiving.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_c4b02567_surprise.wav", "emotion": "surprise", "sentence": "I am going for skydiving.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_b8254aa2_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_b8254aa2_sadness.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_45bec536_surprise.wav", "emotion": "surprise", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_45bec536_sadness.wav", "emotion": "sadness", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_255065e7_anger.wav", "emotion": "anger", "sentence": "You're still working here?", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_255065e7_sadness.wav", "emotion": "sadness", "sentence": "You're still working here?", "expected_emotions": ["anger", "sadness"]}
-{"filename": "671e372ff616106156f72fd3_d6d98405_fear.wav", "emotion": "fear", "sentence": "She was going outside alone at night.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "671e372ff616106156f72fd3_d6d98405_sadness.wav", "emotion": "sadness", "sentence": "She was going outside alone at night.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_f26bfaa5_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_f26bfaa5_fear.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661e7aea959de3433a8f255d_cd8c8b91_sadness.wav", "emotion": "sadness", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661e7aea959de3433a8f255d_cd8c8b91_surprise.wav", "emotion": "surprise", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_584433f5_fear.wav", "emotion": "fear", "sentence": "You will be remembered here.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67203fd3fe9e55e9ec82fc1f_584433f5_sadness.wav", "emotion": "sadness", "sentence": "You will be remembered here.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_da381464_surprise.wav", "emotion": "surprise", "sentence": "You are wearing those shoes here.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_da381464_disgust.wav", "emotion": "disgust", "sentence": "You are wearing those shoes here.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "6691bc059b0182b0bdd7d682_e99968a6_fear.wav", "emotion": "fear", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6691bc059b0182b0bdd7d682_e99968a6_surprise.wav", "emotion": "surprise", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_209d5928_anger.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "6712795a5e34ccb89d7fd40d_209d5928_sadness.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_ea4d3e21_surprise.wav", "emotion": "surprise", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_ea4d3e21_fear.wav", "emotion": "fear", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_2d82a2b1_fear.wav", "emotion": "fear", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_2d82a2b1_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_fae6c996_anger.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_fae6c996_surprise.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_c6f0cf65_sadness.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_c6f0cf65_surprise.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_d1405720_fear.wav", "emotion": "fear", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_d1405720_surprise.wav", "emotion": "surprise", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_d0b6b6f4_fear.wav", "emotion": "fear", "sentence": "I just realized I've had three cups already.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_d0b6b6f4_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've had three cups already.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_eb5723a9_sadness.wav", "emotion": "sadness", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_eb5723a9_surprise.wav", "emotion": "surprise", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "677aa09e06098c948784a33c_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_630589fb_disgust.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_630589fb_sadness.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "67acae4d2601703808e7e666_54ef43ef_fear.wav", "emotion": "fear", "sentence": "She just walked into an abandoned house.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_54ef43ef_surprise.wav", "emotion": "surprise", "sentence": "She just walked into an abandoned house.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67806e9d273c2547826d1d8b_52ceff23_disgust.wav", "emotion": "disgust", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67806e9d273c2547826d1d8b_52ceff23_surprise.wav", "emotion": "surprise", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67876285103f57f54f701beb_5b26beac_neutral.wav", "emotion": "neutral", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "67876285103f57f54f701beb_5b26beac_surprise.wav", "emotion": "surprise", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_5dafd801_fear.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_5dafd801_surprise.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6685bda9fe63421c0f632414_00e2698f_anger.wav", "emotion": "anger", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6685bda9fe63421c0f632414_00e2698f_surprise.wav", "emotion": "surprise", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_9be88a8f_disgust.wav", "emotion": "disgust", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "661bd496ed5e403f399787c8_9be88a8f_sadness.wav", "emotion": "sadness", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "5e4b4332e210130619b398c3_2e5a2c83_surprise.wav", "emotion": "surprise", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5e4b4332e210130619b398c3_2e5a2c83_sadness.wav", "emotion": "sadness", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664f98c80beb5400a141ac91_ab8e2cc5_fear.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_ab8e2cc5_surprise.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_5d83ff9f_anger.wav", "emotion": "anger", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
-{"filename": "664f98c80beb5400a141ac91_5d83ff9f_fear.wav", "emotion": "fear", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_1ca54e82_surprise.wav", "emotion": "surprise", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_1ca54e82_fear.wav", "emotion": "fear", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_efe68913_surprise.wav", "emotion": "surprise", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_efe68913_neutral.wav", "emotion": "neutral", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "667c86d3b9ca760b999914f3_528529ea_fear.wav", "emotion": "fear", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "667c86d3b9ca760b999914f3_528529ea_surprise.wav", "emotion": "surprise", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_6e2e5ed8_fear.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "63ffcb367b500c516d0648a2_6e2e5ed8_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "661e7aea959de3433a8f255d_ea1f36c7_fear.wav", "emotion": "fear", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "661e7aea959de3433a8f255d_ea1f36c7_surprise.wav", "emotion": "surprise", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_9d28cb8d_sadness.wav", "emotion": "sadness", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5e4b4332e210130619b398c3_9d28cb8d_anger.wav", "emotion": "anger", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "5b0df5bde9270900013bdf7f_82788426_fear.wav", "emotion": "fear", "sentence": "She just saw her boss walking towards their table.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5b0df5bde9270900013bdf7f_82788426_surprise.wav", "emotion": "surprise", "sentence": "She just saw her boss walking towards their table.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_8f4e8c06_anger.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_8f4e8c06_surprise.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["anger", "surprise"]}
-{"filename": "671e372ff616106156f72fd3_7614390e_anger.wav", "emotion": "anger", "sentence": "You're going too close.", "expected_emotions": ["anger", "fear"]}
-{"filename": "671e372ff616106156f72fd3_7614390e_fear.wav", "emotion": "fear", "sentence": "You're going too close.", "expected_emotions": ["anger", "fear"]}
-{"filename": "582474a8aac01b0001e45ef9_adf9d846_neutral.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_adf9d846_surprise.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_0a40c75d_sadness.wav", "emotion": "sadness", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "6619cb1e30cb95691a6dd425_0a40c75d_anger.wav", "emotion": "anger", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "661e7aea959de3433a8f255d_c146ebb3_surprise.wav", "emotion": "surprise", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661e7aea959de3433a8f255d_c146ebb3_fear.wav", "emotion": "fear", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67806e9d273c2547826d1d8b_91ea0275_sadness.wav", "emotion": "sadness", "sentence": "I just threw away my career.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "67806e9d273c2547826d1d8b_91ea0275_disgust.wav", "emotion": "disgust", "sentence": "I just threw away my career.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "661e7aea959de3433a8f255d_efe68913_surprise.wav", "emotion": "surprise", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "661e7aea959de3433a8f255d_efe68913_neutral.wav", "emotion": "neutral", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "582474a8aac01b0001e45ef9_ca82ea0a_surprise.wav", "emotion": "surprise", "sentence": "You are going to be photographed.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "582474a8aac01b0001e45ef9_ca82ea0a_fear.wav", "emotion": "fear", "sentence": "You are going to be photographed.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664a6bbe21031d20a2155427_c96143ed_fear.wav", "emotion": "fear", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
-{"filename": "664a6bbe21031d20a2155427_c96143ed_anger.wav", "emotion": "anger", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
-{"filename": "67aca3ffca27d4b3908a7adc_05f7ee9a_surprise.wav", "emotion": "surprise", "sentence": "She just blew her first bubble.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "67aca3ffca27d4b3908a7adc_05f7ee9a_joy.wav", "emotion": "joy", "sentence": "She just blew her first bubble.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "662facfffb363cef00e404a8_0450275d_sadness.wav", "emotion": "sadness", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "662facfffb363cef00e404a8_0450275d_joy.wav", "emotion": "joy", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_29db99b2_surprise.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_29db99b2_fear.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "665be0d7c160ab38d0795255_4834d5b6_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be staying here by myself.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "665be0d7c160ab38d0795255_4834d5b6_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be staying here by myself.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5dd72d2883e3096d755c0f14_2bf3be4f_fear.wav", "emotion": "fear", "sentence": "I didn't expect them to find me hiding here.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5dd72d2883e3096d755c0f14_2bf3be4f_surprise.wav", "emotion": "surprise", "sentence": "I didn't expect them to find me hiding here.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ab8e2cc5_surprise.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_ab8e2cc5_fear.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664f98c80beb5400a141ac91_7ab2d7d8_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_7ab2d7d8_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_97878f47_fear.wav", "emotion": "fear", "sentence": "She brought her phone into an area where phones were strictly prohibited.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_97878f47_surprise.wav", "emotion": "surprise", "sentence": "She brought her phone into an area where phones were strictly prohibited.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_3b1b098d_anger.wav", "emotion": "anger", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_3b1b098d_surprise.wav", "emotion": "surprise", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
-{"filename": "664cf2037353bb98801436b5_d7742a2c_surprise.wav", "emotion": "surprise", "sentence": "He walked into an empty lecture hall wearing only his gym clothes.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "664cf2037353bb98801436b5_d7742a2c_disgust.wav", "emotion": "disgust", "sentence": "He walked into an empty lecture hall wearing only his gym clothes.", "expected_emotions": ["surprise", "disgust"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_e21f0462_surprise.wav", "emotion": "surprise", "sentence": "I just saw something move down here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_e21f0462_fear.wav", "emotion": "fear", "sentence": "I just saw something move down here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_d5404fc9_surprise.wav", "emotion": "surprise", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_d5404fc9_sadness.wav", "emotion": "sadness", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_91dcc346_sadness.wav", "emotion": "sadness", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_91dcc346_fear.wav", "emotion": "fear", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "668758de3a65db8f01f8ee7f_a47ff2b0_sadness.wav", "emotion": "sadness", "sentence": "You're really cutting off all of your hair.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "668758de3a65db8f01f8ee7f_a47ff2b0_surprise.wav", "emotion": "surprise", "sentence": "You're really cutting off all of your hair.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "664cd1c6545aa0f362493dd9_397ff4dd_surprise.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664cd1c6545aa0f362493dd9_397ff4dd_fear.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_00db4dd3_surprise.wav", "emotion": "surprise", "sentence": "You're actually dancing out here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_00db4dd3_fear.wav", "emotion": "fear", "sentence": "You're actually dancing out here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_5fe74091_surprise.wav", "emotion": "surprise", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_5fe74091_neutral.wav", "emotion": "neutral", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "582474a8aac01b0001e45ef9_d70e5b83_sadness.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_d70e5b83_surprise.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_19dcafd5_sadness.wav", "emotion": "sadness", "sentence": "I just found out they're closing this location down.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661bd496ed5e403f399787c8_19dcafd5_surprise.wav", "emotion": "surprise", "sentence": "I just found out they're closing this location down.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_28560560_sadness.wav", "emotion": "sadness", "sentence": "You finally made par.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "604bd44cb5668ba12cc9376e_28560560_joy.wav", "emotion": "joy", "sentence": "You finally made par.", "expected_emotions": ["sadness", "joy"]}
-{"filename": "666f76b68b89442817be678a_9c99b187_surprise.wav", "emotion": "surprise", "sentence": "You are going to be kissed by your crush.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "666f76b68b89442817be678a_9c99b187_joy.wav", "emotion": "joy", "sentence": "You are going to be kissed by your crush.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "674ca794941ad6898969714b_6e2e5ed8_fear.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "674ca794941ad6898969714b_6e2e5ed8_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_8eb872b5_fear.wav", "emotion": "fear", "sentence": "He's been talking like this for years and now he finally has an audience.", "expected_emotions": ["fear", "anger"]}
-{"filename": "665be0d7c160ab38d0795255_8eb872b5_anger.wav", "emotion": "anger", "sentence": "He's been talking like this for years and now he finally has an audience.", "expected_emotions": ["fear", "anger"]}
-{"filename": "664f98c80beb5400a141ac91_1937a910_fear.wav", "emotion": "fear", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_1937a910_surprise.wav", "emotion": "surprise", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_131920dd_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_131920dd_sadness.wav", "emotion": "sadness", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "661e7aea959de3433a8f255d_a932e2da_surprise.wav", "emotion": "surprise", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "661e7aea959de3433a8f255d_a932e2da_sadness.wav", "emotion": "sadness", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664cd1c6545aa0f362493dd9_849130dc_fear.wav", "emotion": "fear", "sentence": "She can't afford another loss.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "664cd1c6545aa0f362493dd9_849130dc_sadness.wav", "emotion": "sadness", "sentence": "She can't afford another loss.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "66ef1fe508a57ab4d42c952d_4a025bc4_disgust.wav", "emotion": "disgust", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "66ef1fe508a57ab4d42c952d_4a025bc4_surprise.wav", "emotion": "surprise", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "672941064eee8977e7916b37_af3a1b14_fear.wav", "emotion": "fear", "sentence": "She's getting her first tattoo.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672941064eee8977e7916b37_af3a1b14_surprise.wav", "emotion": "surprise", "sentence": "She's getting her first tattoo.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_a5df2c69_fear.wav", "emotion": "fear", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_a5df2c69_surprise.wav", "emotion": "surprise", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_b2293e57_fear.wav", "emotion": "fear", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_b2293e57_surprise.wav", "emotion": "surprise", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_87ff6e29_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "5ea734f39a31b90ee2f7b8e0_87ff6e29_sadness.wav", "emotion": "sadness", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_0bf6bf5c_fear.wav", "emotion": "fear", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_0bf6bf5c_sadness.wav", "emotion": "sadness", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "671e372ff616106156f72fd3_20cb0ac0_surprise.wav", "emotion": "surprise", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "671e372ff616106156f72fd3_20cb0ac0_anger.wav", "emotion": "anger", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_5fe74091_surprise.wav", "emotion": "surprise", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_5fe74091_neutral.wav", "emotion": "neutral", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_3d4ba6e6_fear.wav", "emotion": "fear", "sentence": "She kissed him right next to her ex's portrait.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_3d4ba6e6_surprise.wav", "emotion": "surprise", "sentence": "She kissed him right next to her ex's portrait.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_198f3011_sadness.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_198f3011_surprise.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66077bbc1f0ffc0998b8a61f_3a069973_surprise.wav", "emotion": "surprise", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "66077bbc1f0ffc0998b8a61f_3a069973_neutral.wav", "emotion": "neutral", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "6419ae0434916e5dde92e2f2_50b5beab_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone hanging by their feet at the playground.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_50b5beab_fear.wav", "emotion": "fear", "sentence": "I just saw someone hanging by their feet at the playground.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_8cbee814_fear.wav", "emotion": "fear", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_8cbee814_surprise.wav", "emotion": "surprise", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "665be0d7c160ab38d0795255_647ffd8e_sadness.wav", "emotion": "sadness", "sentence": "You are leaving me.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "665be0d7c160ab38d0795255_647ffd8e_fear.wav", "emotion": "fear", "sentence": "You are leaving me.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "664cd1c6545aa0f362493dd9_d8b58e4d_surprise.wav", "emotion": "surprise", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "664cd1c6545aa0f362493dd9_d8b58e4d_anger.wav", "emotion": "anger", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "67aca3ffca27d4b3908a7adc_4e057d7d_sadness.wav", "emotion": "sadness", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_4e057d7d_surprise.wav", "emotion": "surprise", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672268205351c30413c9837e_6080eae4_sadness.wav", "emotion": "sadness", "sentence": "She stood alone at her pew.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "672268205351c30413c9837e_6080eae4_neutral.wav", "emotion": "neutral", "sentence": "She stood alone at her pew.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "67acb9892d24db4d61a856f5_cd67923b_surprise.wav", "emotion": "surprise", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_cd67923b_fear.wav", "emotion": "fear", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "666f76b68b89442817be678a_77a509f0_fear.wav", "emotion": "fear", "sentence": "I never thought I would be getting my blood drawn today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "666f76b68b89442817be678a_77a509f0_surprise.wav", "emotion": "surprise", "sentence": "I never thought I would be getting my blood drawn today.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66077bbc1f0ffc0998b8a61f_b2293e57_fear.wav", "emotion": "fear", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66077bbc1f0ffc0998b8a61f_b2293e57_surprise.wav", "emotion": "surprise", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acb9892d24db4d61a856f5_5260adbc_surprise.wav", "emotion": "surprise", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_5260adbc_fear.wav", "emotion": "fear", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66d72124d778efac4645d1d7_48581123_anger.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "66d72124d778efac4645d1d7_48581123_sadness.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67806e9d273c2547826d1d8b_87ff6e29_sadness.wav", "emotion": "sadness", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67806e9d273c2547826d1d8b_87ff6e29_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "668758de3a65db8f01f8ee7f_1f7b4c3d_surprise.wav", "emotion": "surprise", "sentence": "I just realized I've been eating this stuff for years.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "668758de3a65db8f01f8ee7f_1f7b4c3d_fear.wav", "emotion": "fear", "sentence": "I just realized I've been eating this stuff for years.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6711e09a6906af2fa5b782bd_09f95bf2_fear.wav", "emotion": "fear", "sentence": "I just received an urgent message from my boss while I was wearing these new noise-cancelling headphones.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_09f95bf2_surprise.wav", "emotion": "surprise", "sentence": "I just received an urgent message from my boss while I was wearing these new noise-cancelling headphones.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_01c044ce_fear.wav", "emotion": "fear", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_01c044ce_sadness.wav", "emotion": "sadness", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_08cde112_fear.wav", "emotion": "fear", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_08cde112_surprise.wav", "emotion": "surprise", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_3ea21e2d_surprise.wav", "emotion": "surprise", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_3ea21e2d_fear.wav", "emotion": "fear", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5d09036d59d0de0001310b4e_6e286b48_fear.wav", "emotion": "fear", "sentence": "She was going bald.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5d09036d59d0de0001310b4e_6e286b48_sadness.wav", "emotion": "sadness", "sentence": "She was going bald.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_1ca54e82_fear.wav", "emotion": "fear", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "673c8683b1c8a4c8a79d02d8_1ca54e82_surprise.wav", "emotion": "surprise", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_c4b02567_surprise.wav", "emotion": "surprise", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_c4b02567_fear.wav", "emotion": "fear", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6712795a5e34ccb89d7fd40d_cfc06609_fear.wav", "emotion": "fear", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6712795a5e34ccb89d7fd40d_cfc06609_surprise.wav", "emotion": "surprise", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_2bf75049_surprise.wav", "emotion": "surprise", "sentence": "I just saw my ex standing behind me.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66e28103f28d6e15a3f4f1f0_2bf75049_fear.wav", "emotion": "fear", "sentence": "I just saw my ex standing behind me.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "664f98c80beb5400a141ac91_98b7ce91_sadness.wav", "emotion": "sadness", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "664f98c80beb5400a141ac91_98b7ce91_fear.wav", "emotion": "fear", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67acae4d2601703808e7e666_d75b90fa_fear.wav", "emotion": "fear", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67acae4d2601703808e7e666_d75b90fa_surprise.wav", "emotion": "surprise", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_4c04ab98_fear.wav", "emotion": "fear", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6600d4ab3d166502ff03c3aa_4c04ab98_surprise.wav", "emotion": "surprise", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_f5565a5c_fear.wav", "emotion": "fear", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5aa3ba9bdbdb470001ef40c7_f5565a5c_surprise.wav", "emotion": "surprise", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6745731e75a88802a56be3ef_f2b16873_fear.wav", "emotion": "fear", "sentence": "I'm having triplets.", "expected_emotions": ["fear", "joy"]}
-{"filename": "6745731e75a88802a56be3ef_f2b16873_joy.wav", "emotion": "joy", "sentence": "I'm having triplets.", "expected_emotions": ["fear", "joy"]}
-{"filename": "6699258fcd1cb9db035de794_010de644_anger.wav", "emotion": "anger", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6699258fcd1cb9db035de794_010de644_surprise.wav", "emotion": "surprise", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["anger", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_0e3ef121_surprise.wav", "emotion": "surprise", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_0e3ef121_sadness.wav", "emotion": "sadness", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67acb9892d24db4d61a856f5_209d5928_anger.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67acb9892d24db4d61a856f5_209d5928_sadness.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_2c09ea6f_surprise.wav", "emotion": "surprise", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67780a0e3d8d2cd47bdf4ed9_2c09ea6f_sadness.wav", "emotion": "sadness", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "672941064eee8977e7916b37_0237e064_sadness.wav", "emotion": "sadness", "sentence": "You're really going all out and paying full price.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672941064eee8977e7916b37_0237e064_surprise.wav", "emotion": "surprise", "sentence": "You're really going all out and paying full price.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672941064eee8977e7916b37_9ce47319_surprise.wav", "emotion": "surprise", "sentence": "He just knocked over an entire stack of bricks.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "672941064eee8977e7916b37_9ce47319_anger.wav", "emotion": "anger", "sentence": "He just knocked over an entire stack of bricks.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "6732de5c32981eeab9c67bd1_db88a003_joy.wav", "emotion": "joy", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6732de5c32981eeab9c67bd1_db88a003_surprise.wav", "emotion": "surprise", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_a6cda68d_fear.wav", "emotion": "fear", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "582474a8aac01b0001e45ef9_a6cda68d_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_48581123_anger.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "67abdd72c863ca5fbe8238cb_48581123_sadness.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_26fc7965_surprise.wav", "emotion": "surprise", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_26fc7965_fear.wav", "emotion": "fear", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_aaea7201_surprise.wav", "emotion": "surprise", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_aaea7201_fear.wav", "emotion": "fear", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "668758de3a65db8f01f8ee7f_7b898197_sadness.wav", "emotion": "sadness", "sentence": "She stared at her painting as if she was seeing something different.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "668758de3a65db8f01f8ee7f_7b898197_neutral.wav", "emotion": "neutral", "sentence": "She stared at her painting as if she was seeing something different.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "66439c275cd3cf1ee2426935_f2b16873_joy.wav", "emotion": "joy", "sentence": "I'm having triplets.", "expected_emotions": ["joy", "fear"]}
-{"filename": "66439c275cd3cf1ee2426935_f2b16873_fear.wav", "emotion": "fear", "sentence": "I'm having triplets.", "expected_emotions": ["joy", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_f9bb4d0d_sadness.wav", "emotion": "sadness", "sentence": "She stood up and walked out of her own wedding.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_f9bb4d0d_surprise.wav", "emotion": "surprise", "sentence": "She stood up and walked out of her own wedding.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672268205351c30413c9837e_95f7b102_fear.wav", "emotion": "fear", "sentence": "She swerved across three lanes of traffic.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672268205351c30413c9837e_95f7b102_surprise.wav", "emotion": "surprise", "sentence": "She swerved across three lanes of traffic.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_80c40806_fear.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67abdd72c863ca5fbe8238cb_80c40806_surprise.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_890bee09_sadness.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "5f4ae7cb6b68b56c2acb12c8_890bee09_surprise.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "674ca794941ad6898969714b_f14de307_joy.wav", "emotion": "joy", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "674ca794941ad6898969714b_f14de307_surprise.wav", "emotion": "surprise", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_1306d520_fear.wav", "emotion": "fear", "sentence": "She just saw him standing there.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6711e09a6906af2fa5b782bd_1306d520_surprise.wav", "emotion": "surprise", "sentence": "She just saw him standing there.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67042cdf06ed4052bdf44c07_2afb09ee_sadness.wav", "emotion": "sadness", "sentence": "She has been waiting for hours.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "67042cdf06ed4052bdf44c07_2afb09ee_neutral.wav", "emotion": "neutral", "sentence": "She has been waiting for hours.", "expected_emotions": ["sadness", "neutral"]}
-{"filename": "664cd1c6545aa0f362493dd9_99d69efa_disgust.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "664cd1c6545aa0f362493dd9_99d69efa_sadness.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
-{"filename": "675ef1840636ec90d906ea28_fae6c996_surprise.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "675ef1840636ec90d906ea28_fae6c996_anger.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
-{"filename": "655f8edb8b128e01321fbf88_e99968a6_fear.wav", "emotion": "fear", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "655f8edb8b128e01321fbf88_e99968a6_surprise.wav", "emotion": "surprise", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66d72124d778efac4645d1d7_88aed7cd_sadness.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66d72124d778efac4645d1d7_88aed7cd_fear.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "675ef1840636ec90d906ea28_462143e1_fear.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "675ef1840636ec90d906ea28_462143e1_surprise.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "664f98c80beb5400a141ac91_e7546e45_surprise.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "664f98c80beb5400a141ac91_e7546e45_sadness.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6419ae0434916e5dde92e2f2_0a1eb951_fear.wav", "emotion": "fear", "sentence": "You're actually going up there and giving a speech.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_0a1eb951_surprise.wav", "emotion": "surprise", "sentence": "You're actually going up there and giving a speech.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "672941064eee8977e7916b37_3942e52b_sadness.wav", "emotion": "sadness", "sentence": "She was alone and surrounded by darkness.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "672941064eee8977e7916b37_3942e52b_fear.wav", "emotion": "fear", "sentence": "She was alone and surrounded by darkness.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_d70e5b83_sadness.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66a41af57b243259af76b1c3_d70e5b83_surprise.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_cfc06609_fear.wav", "emotion": "fear", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_cfc06609_surprise.wav", "emotion": "surprise", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_6c7e68ba_sadness.wav", "emotion": "sadness", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_6c7e68ba_surprise.wav", "emotion": "surprise", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_fe591736_sadness.wav", "emotion": "sadness", "sentence": "You're still listening to music.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_fe591736_surprise.wav", "emotion": "surprise", "sentence": "You're still listening to music.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "66c019586569ea36287bd523_93ef79a9_neutral.wav", "emotion": "neutral", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66c019586569ea36287bd523_93ef79a9_surprise.wav", "emotion": "surprise", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_305f21d9_fear.wav", "emotion": "fear", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "66ec3e9d25cdaa3c152b07fb_305f21d9_surprise.wav", "emotion": "surprise", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_189eeeb1_fear.wav", "emotion": "fear", "sentence": "She was caught off guard by his sudden appearance.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "604bd44cb5668ba12cc9376e_189eeeb1_surprise.wav", "emotion": "surprise", "sentence": "She was caught off guard by his sudden appearance.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_fdf1900e_surprise.wav", "emotion": "surprise", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6619cb1e30cb95691a6dd425_fdf1900e_fear.wav", "emotion": "fear", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661bd496ed5e403f399787c8_f5565a5c_surprise.wav", "emotion": "surprise", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661bd496ed5e403f399787c8_f5565a5c_fear.wav", "emotion": "fear", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "5e4b4332e210130619b398c3_91dcc346_fear.wav", "emotion": "fear", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5e4b4332e210130619b398c3_91dcc346_sadness.wav", "emotion": "sadness", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "5dd72d2883e3096d755c0f14_682e1edb_sadness.wav", "emotion": "sadness", "sentence": "I just lit up my last pack of cigarettes.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5dd72d2883e3096d755c0f14_682e1edb_fear.wav", "emotion": "fear", "sentence": "I just lit up my last pack of cigarettes.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "5ea196f089935b04d2ee69d9_3fdbf166_fear.wav", "emotion": "fear", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
-{"filename": "5ea196f089935b04d2ee69d9_3fdbf166_anger.wav", "emotion": "anger", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_86d9911c_surprise.wav", "emotion": "surprise", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "6419ae0434916e5dde92e2f2_86d9911c_joy.wav", "emotion": "joy", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "5e4b4332e210130619b398c3_21096146_neutral.wav", "emotion": "neutral", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5e4b4332e210130619b398c3_21096146_surprise.wav", "emotion": "surprise", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_f49b0ead_sadness.wav", "emotion": "sadness", "sentence": "You are leaving me alone again.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "5d09036d59d0de0001310b4e_f49b0ead_disgust.wav", "emotion": "disgust", "sentence": "You are leaving me alone again.", "expected_emotions": ["sadness", "disgust"]}
-{"filename": "67806e9d273c2547826d1d8b_9615b184_surprise.wav", "emotion": "surprise", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "67806e9d273c2547826d1d8b_9615b184_sadness.wav", "emotion": "sadness", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_25968f77_surprise.wav", "emotion": "surprise", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_25968f77_joy.wav", "emotion": "joy", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["surprise", "joy"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_026b30f8_sadness.wav", "emotion": "sadness", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_026b30f8_surprise.wav", "emotion": "surprise", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "661e7aea959de3433a8f255d_fdf1900e_surprise.wav", "emotion": "surprise", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "661e7aea959de3433a8f255d_fdf1900e_fear.wav", "emotion": "fear", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_3efd2d61_sadness.wav", "emotion": "sadness", "sentence": "She just cut her nail too short.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67a6c7e0be88a8e0b0dad998_3efd2d61_surprise.wav", "emotion": "surprise", "sentence": "She just cut her nail too short.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_b3c4eb47_fear.wav", "emotion": "fear", "sentence": "You're going to have to try this outfit again.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "67aca3ffca27d4b3908a7adc_b3c4eb47_surprise.wav", "emotion": "surprise", "sentence": "You're going to have to try this outfit again.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6619cb1e30cb95691a6dd425_ea1f36c7_surprise.wav", "emotion": "surprise", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6619cb1e30cb95691a6dd425_ea1f36c7_fear.wav", "emotion": "fear", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "67acb9892d24db4d61a856f5_e79b6f74_disgust.wav", "emotion": "disgust", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "67acb9892d24db4d61a856f5_e79b6f74_surprise.wav", "emotion": "surprise", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
-{"filename": "66439c275cd3cf1ee2426935_10969ae0_surprise.wav", "emotion": "surprise", "sentence": "She just flushed something down there.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66439c275cd3cf1ee2426935_10969ae0_fear.wav", "emotion": "fear", "sentence": "She just flushed something down there.", "expected_emotions": ["surprise", "fear"]}
-{"filename": "66a41af57b243259af76b1c3_02da40a9_fear.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "66a41af57b243259af76b1c3_02da40a9_sadness.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["fear", "sadness"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_5dafd801_fear.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6121aaee9d29f0c6e3bc8bea_5dafd801_surprise.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "6419ae0434916e5dde92e2f2_89f649f9_surprise.wav", "emotion": "surprise", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "6419ae0434916e5dde92e2f2_89f649f9_joy.wav", "emotion": "joy", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
-{"filename": "661bd496ed5e403f399787c8_0226896a_sadness.wav", "emotion": "sadness", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "661bd496ed5e403f399787c8_0226896a_anger.wav", "emotion": "anger", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
-{"filename": "6419ae0434916e5dde92e2f2_b4ba40a3_surprise.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "6419ae0434916e5dde92e2f2_b4ba40a3_fear.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
-{"filename": "667c86d3b9ca760b999914f3_088de02f_surprise.wav", "emotion": "surprise", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "667c86d3b9ca760b999914f3_088de02f_neutral.wav", "emotion": "neutral", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
-{"filename": "5ea196f089935b04d2ee69d9_209d5928_anger.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "5ea196f089935b04d2ee69d9_209d5928_sadness.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "63ffcb367b500c516d0648a2_02da40a9_sadness.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "63ffcb367b500c516d0648a2_02da40a9_fear.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
-{"filename": "67876285103f57f54f701beb_c67dbe3c_sadness.wav", "emotion": "sadness", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "67876285103f57f54f701beb_c67dbe3c_surprise.wav", "emotion": "surprise", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_48581123_anger.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "672c4e78eeaae1dfe925f5e2_48581123_sadness.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "655f8edb8b128e01321fbf88_9a6ed6da_fear.wav", "emotion": "fear", "sentence": "You're actually seeing me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "655f8edb8b128e01321fbf88_9a6ed6da_surprise.wav", "emotion": "surprise", "sentence": "You're actually seeing me.", "expected_emotions": ["fear", "surprise"]}
-{"filename": "5d09036d59d0de0001310b4e_f8cbf9bb_anger.wav", "emotion": "anger", "sentence": "I cant believe you did this.", "expected_emotions": ["anger", "sadness"]}
-{"filename": "5d09036d59d0de0001310b4e_f8cbf9bb_sadness.wav", "emotion": "sadness", "sentence": "I cant believe you did this.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "0.wav", "emotion": "fear", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1.wav", "emotion": "sadness", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "2.wav", "emotion": "neutral", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "3.wav", "emotion": "sadness", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "4.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "5.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "6.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "7.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "8.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "9.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "10.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "11.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "12.wav", "emotion": "disgust", "sentence": "You're standing too close.", "expected_emotions": ["disgust", "fear"]}
+{"filename": "13.wav", "emotion": "fear", "sentence": "You're standing too close.", "expected_emotions": ["disgust", "fear"]}
+{"filename": "14.wav", "emotion": "fear", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "15.wav", "emotion": "surprise", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "16.wav", "emotion": "surprise", "sentence": "I just found out I have been studying mold all day.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "17.wav", "emotion": "disgust", "sentence": "I just found out I have been studying mold all day.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "18.wav", "emotion": "surprise", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "19.wav", "emotion": "fear", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "20.wav", "emotion": "sadness", "sentence": "She finally found all of her missing pieces.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "21.wav", "emotion": "surprise", "sentence": "She finally found all of her missing pieces.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "22.wav", "emotion": "fear", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
+{"filename": "23.wav", "emotion": "anger", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
+{"filename": "24.wav", "emotion": "surprise", "sentence": "He just spilled his drink again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "25.wav", "emotion": "sadness", "sentence": "He just spilled his drink again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "26.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "27.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "28.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "29.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "30.wav", "emotion": "surprise", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "31.wav", "emotion": "disgust", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "32.wav", "emotion": "surprise", "sentence": "You're going my way!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "33.wav", "emotion": "joy", "sentence": "You're going my way!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "34.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "35.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "36.wav", "emotion": "surprise", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "37.wav", "emotion": "fear", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "38.wav", "emotion": "surprise", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "39.wav", "emotion": "sadness", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "40.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "41.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "42.wav", "emotion": "surprise", "sentence": "You're really going to have to learn this quickly.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "43.wav", "emotion": "sadness", "sentence": "You're really going to have to learn this quickly.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "44.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
+{"filename": "45.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
+{"filename": "46.wav", "emotion": "surprise", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "47.wav", "emotion": "fear", "sentence": "You're actually going to make it out of here alive.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "48.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "49.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "50.wav", "emotion": "anger", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "51.wav", "emotion": "sadness", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "52.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "53.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "54.wav", "emotion": "surprise", "sentence": "I never thought I'd be holding my old guitar again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "55.wav", "emotion": "sadness", "sentence": "I never thought I'd be holding my old guitar again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "56.wav", "emotion": "surprise", "sentence": "She's cooking alone for the first time.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "57.wav", "emotion": "fear", "sentence": "She's cooking alone for the first time.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "58.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "59.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "60.wav", "emotion": "sadness", "sentence": "You are holding my hand.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "61.wav", "emotion": "surprise", "sentence": "You are holding my hand.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "62.wav", "emotion": "surprise", "sentence": "She saw him staring at her from across the rack of clothes.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "63.wav", "emotion": "disgust", "sentence": "She saw him staring at her from across the rack of clothes.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "64.wav", "emotion": "fear", "sentence": "You're going to have your teeth pulled.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "65.wav", "emotion": "surprise", "sentence": "You're going to have your teeth pulled.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "66.wav", "emotion": "anger", "sentence": "They are ruining their childhood.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "67.wav", "emotion": "sadness", "sentence": "They are ruining their childhood.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "68.wav", "emotion": "sadness", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "69.wav", "emotion": "joy", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "70.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "71.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "72.wav", "emotion": "sadness", "sentence": "She can't afford another loss.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "73.wav", "emotion": "fear", "sentence": "She can't afford another loss.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "74.wav", "emotion": "surprise", "sentence": "You're really going back for another pastry.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "75.wav", "emotion": "sadness", "sentence": "You're really going back for another pastry.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "76.wav", "emotion": "sadness", "sentence": "He was standing too close to the edge.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "77.wav", "emotion": "fear", "sentence": "He was standing too close to the edge.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "78.wav", "emotion": "anger", "sentence": "I don't know what you're talking about.", "expected_emotions": ["anger", "fear"]}
+{"filename": "79.wav", "emotion": "fear", "sentence": "I don't know what you're talking about.", "expected_emotions": ["anger", "fear"]}
+{"filename": "80.wav", "emotion": "surprise", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "81.wav", "emotion": "anger", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "82.wav", "emotion": "sadness", "sentence": "She was alone at her table.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "83.wav", "emotion": "fear", "sentence": "She was alone at her table.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "84.wav", "emotion": "sadness", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "85.wav", "emotion": "anger", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "86.wav", "emotion": "surprise", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "87.wav", "emotion": "fear", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "88.wav", "emotion": "surprise", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "89.wav", "emotion": "sadness", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "90.wav", "emotion": "sadness", "sentence": "You're still not here.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "91.wav", "emotion": "anger", "sentence": "You're still not here.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "92.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "93.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "94.wav", "emotion": "sadness", "sentence": "He just spilled his drink again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "95.wav", "emotion": "surprise", "sentence": "He just spilled his drink again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "96.wav", "emotion": "sadness", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "97.wav", "emotion": "fear", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "98.wav", "emotion": "neutral", "sentence": "You are dancing.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "99.wav", "emotion": "surprise", "sentence": "You are dancing.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "100.wav", "emotion": "fear", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "101.wav", "emotion": "surprise", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "102.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "103.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "104.wav", "emotion": "fear", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "105.wav", "emotion": "surprise", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "106.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "107.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "108.wav", "emotion": "fear", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
+{"filename": "109.wav", "emotion": "surprise", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
+{"filename": "110.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "111.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "112.wav", "emotion": "anger", "sentence": "I just got hit by another stray ball.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "113.wav", "emotion": "surprise", "sentence": "I just got hit by another stray ball.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "114.wav", "emotion": "surprise", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "115.wav", "emotion": "fear", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "116.wav", "emotion": "surprise", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "117.wav", "emotion": "fear", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "118.wav", "emotion": "surprise", "sentence": "He just spent his last quarter.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "119.wav", "emotion": "sadness", "sentence": "He just spent his last quarter.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "120.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
+{"filename": "121.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
+{"filename": "122.wav", "emotion": "surprise", "sentence": "You're going deeper into these woods.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "123.wav", "emotion": "fear", "sentence": "You're going deeper into these woods.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "124.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "125.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "126.wav", "emotion": "anger", "sentence": "I cant believe I just spilled coffee all over my shirt.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "127.wav", "emotion": "surprise", "sentence": "I cant believe I just spilled coffee all over my shirt.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "128.wav", "emotion": "anger", "sentence": "He lost his favorite pair of work gloves.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "129.wav", "emotion": "sadness", "sentence": "He lost his favorite pair of work gloves.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "130.wav", "emotion": "surprise", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "131.wav", "emotion": "fear", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "132.wav", "emotion": "sadness", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "133.wav", "emotion": "disgust", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "134.wav", "emotion": "surprise", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["surprise", "anger"]}
+{"filename": "135.wav", "emotion": "anger", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["surprise", "anger"]}
+{"filename": "136.wav", "emotion": "surprise", "sentence": "She left her stove burning.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "137.wav", "emotion": "neutral", "sentence": "She left her stove burning.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "138.wav", "emotion": "surprise", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "139.wav", "emotion": "fear", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "140.wav", "emotion": "surprise", "sentence": "She saw him walking towards her wearing an unfamiliar red afro.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "141.wav", "emotion": "fear", "sentence": "She saw him walking towards her wearing an unfamiliar red afro.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "142.wav", "emotion": "disgust", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "143.wav", "emotion": "surprise", "sentence": "I just found out I have been dancing all night without realizing my fly was down.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "144.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "145.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "146.wav", "emotion": "fear", "sentence": "You just kicked over your urine sample.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "147.wav", "emotion": "surprise", "sentence": "You just kicked over your urine sample.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "148.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "149.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "150.wav", "emotion": "joy", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "151.wav", "emotion": "surprise", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "152.wav", "emotion": "surprise", "sentence": "I can feel my heart pounding along with this rhythm.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "153.wav", "emotion": "fear", "sentence": "I can feel my heart pounding along with this rhythm.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "154.wav", "emotion": "sadness", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "155.wav", "emotion": "surprise", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "156.wav", "emotion": "fear", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "157.wav", "emotion": "surprise", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "158.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "159.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "160.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "161.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "162.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "163.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "164.wav", "emotion": "surprise", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "165.wav", "emotion": "fear", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "166.wav", "emotion": "joy", "sentence": "I just threw my favorite rose bouquet into the orchestra pit.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "167.wav", "emotion": "sadness", "sentence": "I just threw my favorite rose bouquet into the orchestra pit.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "168.wav", "emotion": "fear", "sentence": "He was trapped.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "169.wav", "emotion": "sadness", "sentence": "He was trapped.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "170.wav", "emotion": "anger", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "171.wav", "emotion": "surprise", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "172.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "173.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "174.wav", "emotion": "fear", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "175.wav", "emotion": "surprise", "sentence": "I'm going into an enclosure full of wild animals.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "176.wav", "emotion": "fear", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "177.wav", "emotion": "surprise", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "178.wav", "emotion": "fear", "sentence": "You're going to be late for your exam!", "expected_emotions": ["fear", "surprise"]}
+{"filename": "179.wav", "emotion": "surprise", "sentence": "You're going to be late for your exam!", "expected_emotions": ["fear", "surprise"]}
+{"filename": "180.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "181.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "182.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["fear", "joy"]}
+{"filename": "183.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["fear", "joy"]}
+{"filename": "184.wav", "emotion": "sadness", "sentence": "I have been forced into participating in this pointless ritual again.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "185.wav", "emotion": "anger", "sentence": "I have been forced into participating in this pointless ritual again.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "186.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "187.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "188.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
+{"filename": "189.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
+{"filename": "190.wav", "emotion": "anger", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "191.wav", "emotion": "surprise", "sentence": "He just got fired from his job as a cab driver.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "192.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "193.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "194.wav", "emotion": "surprise", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "195.wav", "emotion": "neutral", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "196.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "197.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "198.wav", "emotion": "fear", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "199.wav", "emotion": "surprise", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "200.wav", "emotion": "sadness", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "201.wav", "emotion": "joy", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "202.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "203.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "204.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "205.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "206.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "207.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "208.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
+{"filename": "209.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["sadness", "anger"]}
+{"filename": "210.wav", "emotion": "sadness", "sentence": "I can't believe I wasted my entire day printing out these useless documents.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "211.wav", "emotion": "anger", "sentence": "I can't believe I wasted my entire day printing out these useless documents.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "212.wav", "emotion": "surprise", "sentence": "He just walked into his old house.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "213.wav", "emotion": "fear", "sentence": "He just walked into his old house.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "214.wav", "emotion": "surprise", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "215.wav", "emotion": "sadness", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "216.wav", "emotion": "sadness", "sentence": "She had been working at this job long enough.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "217.wav", "emotion": "disgust", "sentence": "She had been working at this job long enough.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "218.wav", "emotion": "fear", "sentence": "You are about to perform your first solo.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "219.wav", "emotion": "surprise", "sentence": "You are about to perform your first solo.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "220.wav", "emotion": "fear", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "221.wav", "emotion": "surprise", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "222.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["anger", "fear"]}
+{"filename": "223.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["anger", "fear"]}
+{"filename": "224.wav", "emotion": "sadness", "sentence": "I'm going for a walk alone.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "225.wav", "emotion": "anger", "sentence": "I'm going for a walk alone.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "226.wav", "emotion": "surprise", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "227.wav", "emotion": "fear", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "228.wav", "emotion": "sadness", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "229.wav", "emotion": "surprise", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "230.wav", "emotion": "fear", "sentence": "I just saw someone I know from my past walk into this auditorium.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "231.wav", "emotion": "surprise", "sentence": "I just saw someone I know from my past walk into this auditorium.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "232.wav", "emotion": "surprise", "sentence": "I just saw someone I didn't expect here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "233.wav", "emotion": "fear", "sentence": "I just saw someone I didn't expect here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "234.wav", "emotion": "surprise", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "235.wav", "emotion": "anger", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "236.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "237.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "238.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "239.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "240.wav", "emotion": "surprise", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "241.wav", "emotion": "sadness", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "242.wav", "emotion": "neutral", "sentence": "The crowd was silent after he fell off his horse.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "243.wav", "emotion": "sadness", "sentence": "The crowd was silent after he fell off his horse.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "244.wav", "emotion": "surprise", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "245.wav", "emotion": "fear", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "246.wav", "emotion": "surprise", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "247.wav", "emotion": "fear", "sentence": "You're going up into the air right now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "248.wav", "emotion": "disgust", "sentence": "I just threw away my career.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "249.wav", "emotion": "sadness", "sentence": "I just threw away my career.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "250.wav", "emotion": "anger", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
+{"filename": "251.wav", "emotion": "surprise", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
+{"filename": "252.wav", "emotion": "fear", "sentence": "I just felt something move under my bed.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "253.wav", "emotion": "surprise", "sentence": "I just felt something move under my bed.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "254.wav", "emotion": "surprise", "sentence": "You're going outside alone at night?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "255.wav", "emotion": "fear", "sentence": "You're going outside alone at night?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "256.wav", "emotion": "surprise", "sentence": "I had no idea people actually did this at campsites.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "257.wav", "emotion": "disgust", "sentence": "I had no idea people actually did this at campsites.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "258.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "259.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "260.wav", "emotion": "sadness", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "261.wav", "emotion": "fear", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "262.wav", "emotion": "anger", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
+{"filename": "263.wav", "emotion": "surprise", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
+{"filename": "264.wav", "emotion": "surprise", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "265.wav", "emotion": "sadness", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "266.wav", "emotion": "neutral", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "267.wav", "emotion": "surprise", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "268.wav", "emotion": "neutral", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "269.wav", "emotion": "sadness", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "270.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "271.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "272.wav", "emotion": "surprise", "sentence": "I just lost my favorite racket.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "273.wav", "emotion": "sadness", "sentence": "I just lost my favorite racket.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "274.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "275.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "276.wav", "emotion": "surprise", "sentence": "She was dancing alone at night near an abandoned stadium.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "277.wav", "emotion": "fear", "sentence": "She was dancing alone at night near an abandoned stadium.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "278.wav", "emotion": "surprise", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "279.wav", "emotion": "joy", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "280.wav", "emotion": "surprise", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "281.wav", "emotion": "sadness", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "282.wav", "emotion": "fear", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "283.wav", "emotion": "sadness", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "284.wav", "emotion": "surprise", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "285.wav", "emotion": "fear", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "286.wav", "emotion": "surprise", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "287.wav", "emotion": "neutral", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "288.wav", "emotion": "surprise", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "289.wav", "emotion": "fear", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "290.wav", "emotion": "surprise", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "291.wav", "emotion": "fear", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "292.wav", "emotion": "surprise", "sentence": "You are going into this blind.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "293.wav", "emotion": "fear", "sentence": "You are going into this blind.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "294.wav", "emotion": "sadness", "sentence": "She was alone at home.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "295.wav", "emotion": "fear", "sentence": "She was alone at home.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "296.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "297.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "298.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "299.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "300.wav", "emotion": "fear", "sentence": "You are going to have to present your project today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "301.wav", "emotion": "surprise", "sentence": "You are going to have to present your project today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "302.wav", "emotion": "surprise", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "303.wav", "emotion": "fear", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "304.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "305.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "306.wav", "emotion": "fear", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "307.wav", "emotion": "surprise", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "308.wav", "emotion": "surprise", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "309.wav", "emotion": "fear", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "310.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "311.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "312.wav", "emotion": "sadness", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "313.wav", "emotion": "fear", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "314.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "315.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "316.wav", "emotion": "fear", "sentence": "She brought an enormous suitcase onto the crowded city bus.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "317.wav", "emotion": "surprise", "sentence": "She brought an enormous suitcase onto the crowded city bus.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "318.wav", "emotion": "anger", "sentence": "She was crying alone at the edge of the ocean.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "319.wav", "emotion": "sadness", "sentence": "She was crying alone at the edge of the ocean.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "320.wav", "emotion": "anger", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "321.wav", "emotion": "sadness", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "322.wav", "emotion": "surprise", "sentence": "You are leaving.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "323.wav", "emotion": "sadness", "sentence": "You are leaving.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "324.wav", "emotion": "surprise", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "325.wav", "emotion": "sadness", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "326.wav", "emotion": "joy", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "327.wav", "emotion": "surprise", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "328.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "329.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "330.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "331.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "332.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "333.wav", "emotion": "anger", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "334.wav", "emotion": "fear", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "335.wav", "emotion": "surprise", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "336.wav", "emotion": "surprise", "sentence": "You're actually watching this movie alone after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "337.wav", "emotion": "sadness", "sentence": "You're actually watching this movie alone after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "338.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "339.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "340.wav", "emotion": "fear", "sentence": "She changed all of her door's locks.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "341.wav", "emotion": "sadness", "sentence": "She changed all of her door's locks.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "342.wav", "emotion": "fear", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "343.wav", "emotion": "surprise", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "344.wav", "emotion": "surprise", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "345.wav", "emotion": "fear", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "346.wav", "emotion": "sadness", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "347.wav", "emotion": "surprise", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "348.wav", "emotion": "fear", "sentence": "You're going up into the air right now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "349.wav", "emotion": "surprise", "sentence": "You're going up into the air right now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "350.wav", "emotion": "surprise", "sentence": "He was wearing only his Speedos and running towards her.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "351.wav", "emotion": "fear", "sentence": "He was wearing only his Speedos and running towards her.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "352.wav", "emotion": "surprise", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "353.wav", "emotion": "neutral", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "354.wav", "emotion": "joy", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "355.wav", "emotion": "surprise", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "356.wav", "emotion": "surprise", "sentence": "You are going to love this flight.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "357.wav", "emotion": "joy", "sentence": "You are going to love this flight.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "358.wav", "emotion": "surprise", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "359.wav", "emotion": "fear", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "360.wav", "emotion": "sadness", "sentence": "You are leaving.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "361.wav", "emotion": "surprise", "sentence": "You are leaving.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "362.wav", "emotion": "sadness", "sentence": "I have some bad news.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "363.wav", "emotion": "fear", "sentence": "I have some bad news.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "364.wav", "emotion": "fear", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "365.wav", "emotion": "surprise", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "366.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "367.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "368.wav", "emotion": "sadness", "sentence": "She will be alone tonight.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "369.wav", "emotion": "fear", "sentence": "She will be alone tonight.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "370.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "371.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "372.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "373.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "374.wav", "emotion": "fear", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "375.wav", "emotion": "surprise", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "376.wav", "emotion": "surprise", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "377.wav", "emotion": "fear", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "378.wav", "emotion": "disgust", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "379.wav", "emotion": "surprise", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "380.wav", "emotion": "neutral", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "381.wav", "emotion": "surprise", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "382.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "383.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "384.wav", "emotion": "fear", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "385.wav", "emotion": "sadness", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "386.wav", "emotion": "neutral", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "387.wav", "emotion": "sadness", "sentence": "I still have some of their old toys.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "388.wav", "emotion": "fear", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "389.wav", "emotion": "sadness", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "390.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "391.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "392.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "393.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "394.wav", "emotion": "joy", "sentence": "You just got kissed by your favorite nurse.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "395.wav", "emotion": "surprise", "sentence": "You just got kissed by your favorite nurse.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "396.wav", "emotion": "sadness", "sentence": "You're actually taking responsibility for your actions.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "397.wav", "emotion": "surprise", "sentence": "You're actually taking responsibility for your actions.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "398.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "399.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "400.wav", "emotion": "surprise", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "401.wav", "emotion": "fear", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "402.wav", "emotion": "fear", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "403.wav", "emotion": "sadness", "sentence": "I don't want my mom to leave me here alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "404.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "405.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "406.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "407.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "408.wav", "emotion": "sadness", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "409.wav", "emotion": "joy", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "410.wav", "emotion": "surprise", "sentence": "I just saw something move out of my eye corner while I was spinning.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "411.wav", "emotion": "fear", "sentence": "I just saw something move out of my eye corner while I was spinning.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "412.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "413.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "414.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
+{"filename": "415.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
+{"filename": "416.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "417.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "418.wav", "emotion": "fear", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "419.wav", "emotion": "surprise", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "420.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "421.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "422.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "423.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "424.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "425.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "426.wav", "emotion": "surprise", "sentence": "You're still wearing those old sandals.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "427.wav", "emotion": "sadness", "sentence": "You're still wearing those old sandals.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "428.wav", "emotion": "surprise", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "429.wav", "emotion": "sadness", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "430.wav", "emotion": "fear", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "431.wav", "emotion": "surprise", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "432.wav", "emotion": "anger", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "433.wav", "emotion": "surprise", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "434.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "435.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "436.wav", "emotion": "surprise", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "437.wav", "emotion": "sadness", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "438.wav", "emotion": "anger", "sentence": "You're going too far out there.", "expected_emotions": ["anger", "fear"]}
+{"filename": "439.wav", "emotion": "fear", "sentence": "You're going too far out there.", "expected_emotions": ["anger", "fear"]}
+{"filename": "440.wav", "emotion": "anger", "sentence": "I just got yelled at by my boss for not meeting this deadline.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "441.wav", "emotion": "sadness", "sentence": "I just got yelled at by my boss for not meeting this deadline.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "442.wav", "emotion": "sadness", "sentence": "I'm running low again.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "443.wav", "emotion": "neutral", "sentence": "I'm running low again.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "444.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "445.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "446.wav", "emotion": "surprise", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "447.wav", "emotion": "disgust", "sentence": "I just realized I've been using this sweaty towel for three days.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "448.wav", "emotion": "neutral", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "449.wav", "emotion": "surprise", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "450.wav", "emotion": "sadness", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "451.wav", "emotion": "surprise", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "452.wav", "emotion": "surprise", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "453.wav", "emotion": "sadness", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "454.wav", "emotion": "surprise", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "455.wav", "emotion": "fear", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "456.wav", "emotion": "anger", "sentence": "I don't want to go outside for recess.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "457.wav", "emotion": "sadness", "sentence": "I don't want to go outside for recess.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "458.wav", "emotion": "surprise", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "459.wav", "emotion": "fear", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "460.wav", "emotion": "surprise", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "461.wav", "emotion": "fear", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "462.wav", "emotion": "surprise", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "463.wav", "emotion": "fear", "sentence": "You're going into your dark basement alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "464.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "465.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "466.wav", "emotion": "neutral", "sentence": "You are cleaning up after everyone else again.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "467.wav", "emotion": "sadness", "sentence": "You are cleaning up after everyone else again.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "468.wav", "emotion": "surprise", "sentence": "She never thought she would see him again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "469.wav", "emotion": "sadness", "sentence": "She never thought she would see him again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "470.wav", "emotion": "surprise", "sentence": "You are holding my hand.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "471.wav", "emotion": "sadness", "sentence": "You are holding my hand.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "472.wav", "emotion": "anger", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "473.wav", "emotion": "sadness", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "474.wav", "emotion": "surprise", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "475.wav", "emotion": "joy", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "476.wav", "emotion": "disgust", "sentence": "She was picking her children up late again.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "477.wav", "emotion": "surprise", "sentence": "She was picking her children up late again.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "478.wav", "emotion": "sadness", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "479.wav", "emotion": "anger", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "480.wav", "emotion": "sadness", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "481.wav", "emotion": "surprise", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "482.wav", "emotion": "neutral", "sentence": "You are going ahead and doing this.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "483.wav", "emotion": "surprise", "sentence": "You are going ahead and doing this.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "484.wav", "emotion": "surprise", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "485.wav", "emotion": "fear", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "486.wav", "emotion": "neutral", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "487.wav", "emotion": "surprise", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "488.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "489.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "490.wav", "emotion": "joy", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "491.wav", "emotion": "surprise", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "492.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "493.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "494.wav", "emotion": "fear", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "495.wav", "emotion": "sadness", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "496.wav", "emotion": "sadness", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "497.wav", "emotion": "fear", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "498.wav", "emotion": "surprise", "sentence": "Are you actually going up there and saying those things out loud?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "499.wav", "emotion": "fear", "sentence": "Are you actually going up there and saying those things out loud?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "500.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "501.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "502.wav", "emotion": "surprise", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "503.wav", "emotion": "fear", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "504.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "505.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "506.wav", "emotion": "sadness", "sentence": "She had been feeding them for years but now they were gone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "507.wav", "emotion": "fear", "sentence": "She had been feeding them for years but now they were gone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "508.wav", "emotion": "surprise", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "509.wav", "emotion": "sadness", "sentence": "I just realized I've been listening to this same episode for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "510.wav", "emotion": "sadness", "sentence": "She was going outside alone at night.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "511.wav", "emotion": "fear", "sentence": "She was going outside alone at night.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "512.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "513.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "514.wav", "emotion": "fear", "sentence": "You're sailing alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "515.wav", "emotion": "surprise", "sentence": "You're sailing alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "516.wav", "emotion": "sadness", "sentence": "I never thought I would be learning about this topic.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "517.wav", "emotion": "surprise", "sentence": "I never thought I would be learning about this topic.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "518.wav", "emotion": "sadness", "sentence": "I just sold my last roll of film.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "519.wav", "emotion": "joy", "sentence": "I just sold my last roll of film.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "520.wav", "emotion": "fear", "sentence": "He yelled at her.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "521.wav", "emotion": "surprise", "sentence": "He yelled at her.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "522.wav", "emotion": "fear", "sentence": "She heard footsteps coming from inside.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "523.wav", "emotion": "surprise", "sentence": "She heard footsteps coming from inside.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "524.wav", "emotion": "neutral", "sentence": "You're actually standing close enough for me to see your eyes.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "525.wav", "emotion": "surprise", "sentence": "You're actually standing close enough for me to see your eyes.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "526.wav", "emotion": "fear", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "527.wav", "emotion": "sadness", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "528.wav", "emotion": "surprise", "sentence": "I never thought I'd see them end up together like this.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "529.wav", "emotion": "sadness", "sentence": "I never thought I'd see them end up together like this.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "530.wav", "emotion": "surprise", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "531.wav", "emotion": "fear", "sentence": "I just saw my ex standing at our old apartment.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "532.wav", "emotion": "surprise", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "533.wav", "emotion": "fear", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "534.wav", "emotion": "disgust", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "535.wav", "emotion": "surprise", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "536.wav", "emotion": "surprise", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "537.wav", "emotion": "fear", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "538.wav", "emotion": "fear", "sentence": "She has never cooked anything like this before.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "539.wav", "emotion": "surprise", "sentence": "She has never cooked anything like this before.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "540.wav", "emotion": "fear", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "541.wav", "emotion": "surprise", "sentence": "I just rode my bike down this huge hill near our campsite.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "542.wav", "emotion": "surprise", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "543.wav", "emotion": "fear", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "544.wav", "emotion": "surprise", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "545.wav", "emotion": "neutral", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "546.wav", "emotion": "surprise", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "547.wav", "emotion": "fear", "sentence": "I just saw someone chewing their own hair.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "548.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "549.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "550.wav", "emotion": "surprise", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "551.wav", "emotion": "fear", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "552.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "553.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "554.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "555.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "556.wav", "emotion": "surprise", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "557.wav", "emotion": "neutral", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "558.wav", "emotion": "fear", "sentence": "You're eating your sandwich under my bed.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "559.wav", "emotion": "surprise", "sentence": "You're eating your sandwich under my bed.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "560.wav", "emotion": "fear", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "561.wav", "emotion": "surprise", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "562.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "563.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "564.wav", "emotion": "neutral", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "565.wav", "emotion": "surprise", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "566.wav", "emotion": "fear", "sentence": "You're asking me for help.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "567.wav", "emotion": "surprise", "sentence": "You're asking me for help.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "568.wav", "emotion": "joy", "sentence": "You're going my way!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "569.wav", "emotion": "surprise", "sentence": "You're going my way!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "570.wav", "emotion": "surprise", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "571.wav", "emotion": "fear", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "572.wav", "emotion": "sadness", "sentence": "You are not doing your job.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "573.wav", "emotion": "anger", "sentence": "You are not doing your job.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "574.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "575.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "576.wav", "emotion": "surprise", "sentence": "I never thought I'd be singing here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "577.wav", "emotion": "sadness", "sentence": "I never thought I'd be singing here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "578.wav", "emotion": "surprise", "sentence": "She fell down and started laughing.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "579.wav", "emotion": "joy", "sentence": "She fell down and started laughing.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "580.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "581.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "582.wav", "emotion": "sadness", "sentence": "I can't believe I have nothing else left.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "583.wav", "emotion": "anger", "sentence": "I can't believe I have nothing else left.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "584.wav", "emotion": "surprise", "sentence": "He walked up and started hitting on her.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "585.wav", "emotion": "disgust", "sentence": "He walked up and started hitting on her.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "586.wav", "emotion": "surprise", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "587.wav", "emotion": "fear", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "588.wav", "emotion": "disgust", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "589.wav", "emotion": "sadness", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "590.wav", "emotion": "joy", "sentence": "She just blew her first bubble.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "591.wav", "emotion": "surprise", "sentence": "She just blew her first bubble.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "592.wav", "emotion": "sadness", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "593.wav", "emotion": "disgust", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "594.wav", "emotion": "fear", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
+{"filename": "595.wav", "emotion": "anger", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
+{"filename": "596.wav", "emotion": "surprise", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "597.wav", "emotion": "fear", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "598.wav", "emotion": "surprise", "sentence": "I just lost my high score.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "599.wav", "emotion": "sadness", "sentence": "I just lost my high score.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "600.wav", "emotion": "surprise", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "601.wav", "emotion": "fear", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "602.wav", "emotion": "surprise", "sentence": "He just won first prize at his very first rodeo.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "603.wav", "emotion": "joy", "sentence": "He just won first prize at his very first rodeo.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "604.wav", "emotion": "surprise", "sentence": "He stood uncomfortably close.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "605.wav", "emotion": "disgust", "sentence": "He stood uncomfortably close.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "606.wav", "emotion": "disgust", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "607.wav", "emotion": "sadness", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "608.wav", "emotion": "fear", "sentence": "You're going into those woods by yourself.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "609.wav", "emotion": "surprise", "sentence": "You're going into those woods by yourself.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "610.wav", "emotion": "surprise", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "611.wav", "emotion": "fear", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "612.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "613.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "614.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "615.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "616.wav", "emotion": "neutral", "sentence": "I just found out I can buy this rifle online.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "617.wav", "emotion": "surprise", "sentence": "I just found out I can buy this rifle online.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "618.wav", "emotion": "joy", "sentence": "I just kissed my personal trainer at the gym.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "619.wav", "emotion": "surprise", "sentence": "I just kissed my personal trainer at the gym.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "620.wav", "emotion": "fear", "sentence": "She walked alone into the dimly lit convenience store.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "621.wav", "emotion": "sadness", "sentence": "She walked alone into the dimly lit convenience store.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "622.wav", "emotion": "sadness", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "623.wav", "emotion": "surprise", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "624.wav", "emotion": "joy", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "625.wav", "emotion": "surprise", "sentence": "She couldn't believe she finally got an upgrade.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "626.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "627.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "628.wav", "emotion": "sadness", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "629.wav", "emotion": "fear", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "630.wav", "emotion": "surprise", "sentence": "She had never worn anything so constricting before.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "631.wav", "emotion": "fear", "sentence": "She had never worn anything so constricting before.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "632.wav", "emotion": "surprise", "sentence": "She just found out she wasn't alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "633.wav", "emotion": "fear", "sentence": "She just found out she wasn't alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "634.wav", "emotion": "surprise", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "635.wav", "emotion": "fear", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "636.wav", "emotion": "sadness", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "637.wav", "emotion": "anger", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "638.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "639.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "640.wav", "emotion": "fear", "sentence": "I am about to run into this huge crowd of people.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "641.wav", "emotion": "surprise", "sentence": "I am about to run into this huge crowd of people.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "642.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "643.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "644.wav", "emotion": "sadness", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "645.wav", "emotion": "disgust", "sentence": "She couldn't believe she had been working there for five years.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "646.wav", "emotion": "fear", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "647.wav", "emotion": "surprise", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "648.wav", "emotion": "neutral", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "649.wav", "emotion": "sadness", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "650.wav", "emotion": "fear", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
+{"filename": "651.wav", "emotion": "neutral", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
+{"filename": "652.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "653.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "654.wav", "emotion": "sadness", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "655.wav", "emotion": "surprise", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "656.wav", "emotion": "sadness", "sentence": "I'm going up this mountain alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "657.wav", "emotion": "fear", "sentence": "I'm going up this mountain alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "658.wav", "emotion": "sadness", "sentence": "She hung up her wedding dress.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "659.wav", "emotion": "surprise", "sentence": "She hung up her wedding dress.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "660.wav", "emotion": "surprise", "sentence": "I never thought I'd be picking up this much of my life.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "661.wav", "emotion": "sadness", "sentence": "I never thought I'd be picking up this much of my life.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "662.wav", "emotion": "surprise", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "663.wav", "emotion": "fear", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "664.wav", "emotion": "fear", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "665.wav", "emotion": "sadness", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "666.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
+{"filename": "667.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
+{"filename": "668.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "669.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "670.wav", "emotion": "sadness", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "671.wav", "emotion": "surprise", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "672.wav", "emotion": "surprise", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "673.wav", "emotion": "sadness", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "674.wav", "emotion": "surprise", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "675.wav", "emotion": "neutral", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "676.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "677.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "678.wav", "emotion": "sadness", "sentence": "I've been listening to this hymn for years.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "679.wav", "emotion": "neutral", "sentence": "I've been listening to this hymn for years.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "680.wav", "emotion": "anger", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
+{"filename": "681.wav", "emotion": "fear", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
+{"filename": "682.wav", "emotion": "fear", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "683.wav", "emotion": "sadness", "sentence": "She heard footsteps outside her door.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "684.wav", "emotion": "surprise", "sentence": "She ate something she shouldn't have.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "685.wav", "emotion": "fear", "sentence": "She ate something she shouldn't have.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "686.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "687.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "688.wav", "emotion": "fear", "sentence": "You're going to crash your car.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "689.wav", "emotion": "surprise", "sentence": "You're going to crash your car.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "690.wav", "emotion": "surprise", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "691.wav", "emotion": "sadness", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "692.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "693.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "694.wav", "emotion": "surprise", "sentence": "You're really going through all those cloves of garlic.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "695.wav", "emotion": "sadness", "sentence": "You're really going through all those cloves of garlic.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "696.wav", "emotion": "neutral", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "697.wav", "emotion": "surprise", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "698.wav", "emotion": "surprise", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "699.wav", "emotion": "anger", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "700.wav", "emotion": "fear", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "701.wav", "emotion": "sadness", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "702.wav", "emotion": "surprise", "sentence": "You are going into this ancient place alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "703.wav", "emotion": "fear", "sentence": "You are going into this ancient place alone.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "704.wav", "emotion": "surprise", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "705.wav", "emotion": "sadness", "sentence": "I never thought I'd be making another wish here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "706.wav", "emotion": "surprise", "sentence": "You are completely alone at this crowded party.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "707.wav", "emotion": "fear", "sentence": "You are completely alone at this crowded party.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "708.wav", "emotion": "sadness", "sentence": "He had lost all his money at the roulette table.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "709.wav", "emotion": "surprise", "sentence": "He had lost all his money at the roulette table.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "710.wav", "emotion": "sadness", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "711.wav", "emotion": "surprise", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "712.wav", "emotion": "anger", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "713.wav", "emotion": "surprise", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "714.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "715.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "716.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "717.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "718.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "719.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "720.wav", "emotion": "sadness", "sentence": "I never thought I'd be developing my own photographs again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "721.wav", "emotion": "surprise", "sentence": "I never thought I'd be developing my own photographs again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "722.wav", "emotion": "fear", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "723.wav", "emotion": "surprise", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "724.wav", "emotion": "neutral", "sentence": "You flushed something down there.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "725.wav", "emotion": "surprise", "sentence": "You flushed something down there.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "726.wav", "emotion": "fear", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "727.wav", "emotion": "sadness", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "728.wav", "emotion": "sadness", "sentence": "I never thought I'd be putting this old thing back up again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "729.wav", "emotion": "surprise", "sentence": "I never thought I'd be putting this old thing back up again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "730.wav", "emotion": "surprise", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "731.wav", "emotion": "fear", "sentence": "She dove into the deep end.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "732.wav", "emotion": "surprise", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "733.wav", "emotion": "sadness", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "734.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "735.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "736.wav", "emotion": "sadness", "sentence": "I'm putting this stupid mascara back where I found it.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "737.wav", "emotion": "anger", "sentence": "I'm putting this stupid mascara back where I found it.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "738.wav", "emotion": "sadness", "sentence": "You ruined another beautiful symphony.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "739.wav", "emotion": "disgust", "sentence": "You ruined another beautiful symphony.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "740.wav", "emotion": "surprise", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "741.wav", "emotion": "fear", "sentence": "You're going into this run-down old place?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "742.wav", "emotion": "surprise", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "743.wav", "emotion": "sadness", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "744.wav", "emotion": "joy", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "745.wav", "emotion": "surprise", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "746.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "747.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "748.wav", "emotion": "surprise", "sentence": "She wore her highest stilettos despite being surrounded by uneven grass and balloons floating away.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "749.wav", "emotion": "fear", "sentence": "She wore her highest stilettos despite being surrounded by uneven grass and balloons floating away.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "750.wav", "emotion": "surprise", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "751.wav", "emotion": "neutral", "sentence": "She had never seen so many hair clippers before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "752.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "753.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "754.wav", "emotion": "surprise", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "755.wav", "emotion": "neutral", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "756.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "757.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "758.wav", "emotion": "surprise", "sentence": "I dropped the pass.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "759.wav", "emotion": "sadness", "sentence": "I dropped the pass.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "760.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "761.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "762.wav", "emotion": "fear", "sentence": "I just realized I left my passport at home.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "763.wav", "emotion": "surprise", "sentence": "I just realized I left my passport at home.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "764.wav", "emotion": "surprise", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "765.wav", "emotion": "fear", "sentence": "I just saw my name written inside this stall.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "766.wav", "emotion": "surprise", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "767.wav", "emotion": "fear", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "768.wav", "emotion": "surprise", "sentence": "She heard footsteps coming from her cell.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "769.wav", "emotion": "fear", "sentence": "She heard footsteps coming from her cell.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "770.wav", "emotion": "surprise", "sentence": "You're actually going through with this and taking off your shoes!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "771.wav", "emotion": "joy", "sentence": "You're actually going through with this and taking off your shoes!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "772.wav", "emotion": "surprise", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "773.wav", "emotion": "sadness", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "774.wav", "emotion": "surprise", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "775.wav", "emotion": "neutral", "sentence": "She had never seen such large fish before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "776.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "777.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "778.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "779.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "780.wav", "emotion": "neutral", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "781.wav", "emotion": "surprise", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "782.wav", "emotion": "anger", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
+{"filename": "783.wav", "emotion": "sadness", "sentence": "You really can't even be bothered to restock this shelf?", "expected_emotions": ["anger", "sadness"]}
+{"filename": "784.wav", "emotion": "surprise", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "785.wav", "emotion": "sadness", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "786.wav", "emotion": "surprise", "sentence": "You are now operating this massive machine.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "787.wav", "emotion": "fear", "sentence": "You are now operating this massive machine.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "788.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "789.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "790.wav", "emotion": "sadness", "sentence": "They are ruining their childhood.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "791.wav", "emotion": "anger", "sentence": "They are ruining their childhood.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "792.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "793.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "794.wav", "emotion": "surprise", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "795.wav", "emotion": "fear", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "796.wav", "emotion": "fear", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "797.wav", "emotion": "surprise", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "798.wav", "emotion": "anger", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "799.wav", "emotion": "surprise", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "800.wav", "emotion": "anger", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "801.wav", "emotion": "sadness", "sentence": "I have been waiting for what feels like forever.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "802.wav", "emotion": "surprise", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "803.wav", "emotion": "fear", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "804.wav", "emotion": "fear", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "805.wav", "emotion": "sadness", "sentence": "I am standing alone at night near an empty and darkened tennis court.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "806.wav", "emotion": "surprise", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "807.wav", "emotion": "fear", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "808.wav", "emotion": "surprise", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "809.wav", "emotion": "fear", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "810.wav", "emotion": "surprise", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "811.wav", "emotion": "fear", "sentence": "I just found out I have been counting this same stack of bills for hours.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "812.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this copy center.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "813.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this copy center.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "814.wav", "emotion": "fear", "sentence": "She just saw her print job was going to cost $500.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "815.wav", "emotion": "surprise", "sentence": "She just saw her print job was going to cost $500.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "816.wav", "emotion": "neutral", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "817.wav", "emotion": "sadness", "sentence": "I'm running low again.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "818.wav", "emotion": "surprise", "sentence": "I just found my old childhood TV.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "819.wav", "emotion": "neutral", "sentence": "I just found my old childhood TV.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "820.wav", "emotion": "fear", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "821.wav", "emotion": "surprise", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "822.wav", "emotion": "sadness", "sentence": "She found out she had been sleeping alone.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "823.wav", "emotion": "surprise", "sentence": "She found out she had been sleeping alone.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "824.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "825.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "826.wav", "emotion": "surprise", "sentence": "He just told me he makes $100k per year.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "827.wav", "emotion": "anger", "sentence": "He just told me he makes $100k per year.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "828.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
+{"filename": "829.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
+{"filename": "830.wav", "emotion": "fear", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "831.wav", "emotion": "surprise", "sentence": "She held his hand tightly as they walked into the dimly lit pharmacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "832.wav", "emotion": "sadness", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "833.wav", "emotion": "surprise", "sentence": "I never thought I'd be asking someone for help like this.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "834.wav", "emotion": "sadness", "sentence": "I just tripped and fell onto my butt.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "835.wav", "emotion": "surprise", "sentence": "I just tripped and fell onto my butt.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "836.wav", "emotion": "surprise", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "837.wav", "emotion": "joy", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "838.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "839.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "840.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "841.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "842.wav", "emotion": "sadness", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "843.wav", "emotion": "surprise", "sentence": "I never knew my grandmother used to paint.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "844.wav", "emotion": "anger", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "845.wav", "emotion": "surprise", "sentence": "She's having another loud party tonight.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "846.wav", "emotion": "fear", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
+{"filename": "847.wav", "emotion": "anger", "sentence": "She's been seen going into his office alone at night.", "expected_emotions": ["fear", "anger"]}
+{"filename": "848.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "849.wav", "emotion": "anger", "sentence": "I just got an unexpected message from my ex.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "850.wav", "emotion": "surprise", "sentence": "She just got assigned as lead reporter for tonight's breaking story.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "851.wav", "emotion": "neutral", "sentence": "She just got assigned as lead reporter for tonight's breaking story.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "852.wav", "emotion": "anger", "sentence": "I am so sick of these stupid rules.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "853.wav", "emotion": "sadness", "sentence": "I am so sick of these stupid rules.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "854.wav", "emotion": "surprise", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "855.wav", "emotion": "disgust", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "856.wav", "emotion": "sadness", "sentence": "You're going to have to get used to taking baths alone now.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "857.wav", "emotion": "neutral", "sentence": "You're going to have to get used to taking baths alone now.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "858.wav", "emotion": "surprise", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "859.wav", "emotion": "sadness", "sentence": "You're really going back there.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "860.wav", "emotion": "fear", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "861.wav", "emotion": "surprise", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "862.wav", "emotion": "fear", "sentence": "I just saw my crush walk into this sketchy underground bowling alley.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "863.wav", "emotion": "surprise", "sentence": "I just saw my crush walk into this sketchy underground bowling alley.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "864.wav", "emotion": "fear", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "865.wav", "emotion": "sadness", "sentence": "I'm going back down there alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "866.wav", "emotion": "sadness", "sentence": "You just lost your favorite mug.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "867.wav", "emotion": "surprise", "sentence": "You just lost your favorite mug.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "868.wav", "emotion": "fear", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "869.wav", "emotion": "surprise", "sentence": "You're actually wearing your new swimsuit.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "870.wav", "emotion": "sadness", "sentence": "I am so tired of this.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "871.wav", "emotion": "anger", "sentence": "I am so tired of this.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "872.wav", "emotion": "fear", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "873.wav", "emotion": "surprise", "sentence": "She just cut her own hair.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "874.wav", "emotion": "anger", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "875.wav", "emotion": "sadness", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "876.wav", "emotion": "surprise", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "877.wav", "emotion": "fear", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "878.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "879.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "880.wav", "emotion": "fear", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "881.wav", "emotion": "sadness", "sentence": "She will be alone tonight.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "882.wav", "emotion": "surprise", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "883.wav", "emotion": "disgust", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "884.wav", "emotion": "neutral", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "885.wav", "emotion": "surprise", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "886.wav", "emotion": "sadness", "sentence": "You're really going down there.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "887.wav", "emotion": "surprise", "sentence": "You're really going down there.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "888.wav", "emotion": "fear", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "889.wav", "emotion": "surprise", "sentence": "She walked into her first day of work at the haunted mansion.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "890.wav", "emotion": "surprise", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "891.wav", "emotion": "sadness", "sentence": "I never thought I'd be washing away my tears down here.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "892.wav", "emotion": "sadness", "sentence": "You just found out you are making less than your coworker.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "893.wav", "emotion": "surprise", "sentence": "You just found out you are making less than your coworker.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "894.wav", "emotion": "surprise", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "895.wav", "emotion": "disgust", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "896.wav", "emotion": "fear", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "897.wav", "emotion": "surprise", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "898.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
+{"filename": "899.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["surprise", "anger"]}
+{"filename": "900.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "901.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "902.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "903.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "904.wav", "emotion": "fear", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
+{"filename": "905.wav", "emotion": "neutral", "sentence": "You are going into your darkened bedroom alone.", "expected_emotions": ["fear", "neutral"]}
+{"filename": "906.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this very same lobby.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "907.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this very same lobby.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "908.wav", "emotion": "sadness", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "909.wav", "emotion": "surprise", "sentence": "I just found out I have been sleeping for three days.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "910.wav", "emotion": "surprise", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "911.wav", "emotion": "sadness", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "912.wav", "emotion": "surprise", "sentence": "She just got her friend completely soaked.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "913.wav", "emotion": "joy", "sentence": "She just got her friend completely soaked.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "914.wav", "emotion": "sadness", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "915.wav", "emotion": "surprise", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "916.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "917.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "918.wav", "emotion": "sadness", "sentence": "I'm going back down there alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "919.wav", "emotion": "fear", "sentence": "I'm going back down there alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "920.wav", "emotion": "sadness", "sentence": "You're really drinking just plain old tapwater?", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "921.wav", "emotion": "surprise", "sentence": "You're really drinking just plain old tapwater?", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "922.wav", "emotion": "fear", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "923.wav", "emotion": "surprise", "sentence": "The students were not prepared for what happened next.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "924.wav", "emotion": "surprise", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "925.wav", "emotion": "fear", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "926.wav", "emotion": "surprise", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "927.wav", "emotion": "fear", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "928.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "929.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "930.wav", "emotion": "fear", "sentence": "She dove into the deep end of the empty swimming pool.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "931.wav", "emotion": "surprise", "sentence": "She dove into the deep end of the empty swimming pool.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "932.wav", "emotion": "surprise", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "933.wav", "emotion": "neutral", "sentence": "I just saw my old friend walking down the street.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "934.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "935.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "936.wav", "emotion": "sadness", "sentence": "I'm running out of space.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "937.wav", "emotion": "fear", "sentence": "I'm running out of space.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "938.wav", "emotion": "surprise", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "939.wav", "emotion": "sadness", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "940.wav", "emotion": "surprise", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "941.wav", "emotion": "fear", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "942.wav", "emotion": "surprise", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "943.wav", "emotion": "sadness", "sentence": "She spent her birthday all by herself.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "944.wav", "emotion": "joy", "sentence": "I finally got sober.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "945.wav", "emotion": "sadness", "sentence": "I finally got sober.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "946.wav", "emotion": "fear", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
+{"filename": "947.wav", "emotion": "anger", "sentence": "You're telling me we have another meeting scheduled for today?", "expected_emotions": ["fear", "anger"]}
+{"filename": "948.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "949.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "950.wav", "emotion": "anger", "sentence": "I just got kicked out of my own game.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "951.wav", "emotion": "sadness", "sentence": "I just got kicked out of my own game.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "952.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "953.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "954.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "955.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "956.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "957.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "958.wav", "emotion": "fear", "sentence": "You're going near those murky waters.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "959.wav", "emotion": "surprise", "sentence": "You're going near those murky waters.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "960.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "961.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "962.wav", "emotion": "sadness", "sentence": "I've been writing this novel for years and I still haven't finished.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "963.wav", "emotion": "neutral", "sentence": "I've been writing this novel for years and I still haven't finished.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "964.wav", "emotion": "surprise", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "965.wav", "emotion": "anger", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "966.wav", "emotion": "surprise", "sentence": "I just made my very first dunk.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "967.wav", "emotion": "joy", "sentence": "I just made my very first dunk.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "968.wav", "emotion": "surprise", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "969.wav", "emotion": "sadness", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "970.wav", "emotion": "neutral", "sentence": "She had never walked through this part of the field before.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "971.wav", "emotion": "surprise", "sentence": "She had never walked through this part of the field before.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "972.wav", "emotion": "fear", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "973.wav", "emotion": "surprise", "sentence": "She just saw her name carved into one of the tombstones.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "974.wav", "emotion": "surprise", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "975.wav", "emotion": "fear", "sentence": "You are about to perform your first solo.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "976.wav", "emotion": "sadness", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "977.wav", "emotion": "joy", "sentence": "I finally got sober.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "978.wav", "emotion": "surprise", "sentence": "She mentioned her faith while getting a haircut.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "979.wav", "emotion": "neutral", "sentence": "She mentioned her faith while getting a haircut.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "980.wav", "emotion": "disgust", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "981.wav", "emotion": "surprise", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "982.wav", "emotion": "surprise", "sentence": "They were having an affair.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "983.wav", "emotion": "neutral", "sentence": "They were having an affair.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "984.wav", "emotion": "anger", "sentence": "You're surrounded.", "expected_emotions": ["anger", "fear"]}
+{"filename": "985.wav", "emotion": "fear", "sentence": "You're surrounded.", "expected_emotions": ["anger", "fear"]}
+{"filename": "986.wav", "emotion": "joy", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "987.wav", "emotion": "sadness", "sentence": "You're finally alone.", "expected_emotions": ["joy", "sadness"]}
+{"filename": "988.wav", "emotion": "surprise", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "989.wav", "emotion": "sadness", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "990.wav", "emotion": "anger", "sentence": "You're going to have to get out of here now.", "expected_emotions": ["anger", "fear"]}
+{"filename": "991.wav", "emotion": "fear", "sentence": "You're going to have to get out of here now.", "expected_emotions": ["anger", "fear"]}
+{"filename": "992.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "993.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "994.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "995.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "996.wav", "emotion": "sadness", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "997.wav", "emotion": "surprise", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "998.wav", "emotion": "fear", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["fear", "anger"]}
+{"filename": "999.wav", "emotion": "anger", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1000.wav", "emotion": "surprise", "sentence": "You are standing alone at this beautiful mountaintop.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1001.wav", "emotion": "sadness", "sentence": "You are standing alone at this beautiful mountaintop.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1002.wav", "emotion": "fear", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1003.wav", "emotion": "surprise", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1004.wav", "emotion": "fear", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1005.wav", "emotion": "sadness", "sentence": "I'm not sure if I can make this game.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1006.wav", "emotion": "sadness", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1007.wav", "emotion": "anger", "sentence": "You're still wearing those ridiculous shoes while cooking dinner.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1008.wav", "emotion": "surprise", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1009.wav", "emotion": "neutral", "sentence": "You flushed something down there.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1010.wav", "emotion": "fear", "sentence": "You've really done something this time.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1011.wav", "emotion": "surprise", "sentence": "You've really done something this time.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1012.wav", "emotion": "neutral", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1013.wav", "emotion": "surprise", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1014.wav", "emotion": "surprise", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1015.wav", "emotion": "sadness", "sentence": "You're sending all those packages by yourself?", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1016.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1017.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1018.wav", "emotion": "surprise", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1019.wav", "emotion": "sadness", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1020.wav", "emotion": "fear", "sentence": "You're going deeper into these woods.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1021.wav", "emotion": "surprise", "sentence": "You're going deeper into these woods.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1022.wav", "emotion": "sadness", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1023.wav", "emotion": "surprise", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1024.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1025.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1026.wav", "emotion": "surprise", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1027.wav", "emotion": "fear", "sentence": "The dog suddenly appeared at her doorstep.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1028.wav", "emotion": "disgust", "sentence": "She showed her belly button ring.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1029.wav", "emotion": "surprise", "sentence": "She showed her belly button ring.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1030.wav", "emotion": "fear", "sentence": "You're really going through all this trouble just for your faith.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1031.wav", "emotion": "surprise", "sentence": "You're really going through all this trouble just for your faith.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1032.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1033.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1034.wav", "emotion": "fear", "sentence": "She saw him standing alone at dusk.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1035.wav", "emotion": "surprise", "sentence": "She saw him standing alone at dusk.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1036.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1037.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1038.wav", "emotion": "surprise", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1039.wav", "emotion": "fear", "sentence": "He walked into the empty parking garage alone at midnight.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1040.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1041.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1042.wav", "emotion": "sadness", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1043.wav", "emotion": "surprise", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1044.wav", "emotion": "fear", "sentence": "He was not going anywhere until he told them what they wanted.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1045.wav", "emotion": "surprise", "sentence": "He was not going anywhere until he told them what they wanted.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1046.wav", "emotion": "sadness", "sentence": "You're going to have trouble filling out this entire thing.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1047.wav", "emotion": "surprise", "sentence": "You're going to have trouble filling out this entire thing.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1048.wav", "emotion": "anger", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1049.wav", "emotion": "surprise", "sentence": "You're eating those wildberries again!", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1050.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1051.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1052.wav", "emotion": "fear", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1053.wav", "emotion": "sadness", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1054.wav", "emotion": "sadness", "sentence": "I can't believe I've ended up here again.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1055.wav", "emotion": "disgust", "sentence": "I can't believe I've ended up here again.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1056.wav", "emotion": "fear", "sentence": "She just flushed something down there.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1057.wav", "emotion": "surprise", "sentence": "She just flushed something down there.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1058.wav", "emotion": "surprise", "sentence": "She didn't see him fall from scaffolding.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1059.wav", "emotion": "fear", "sentence": "She didn't see him fall from scaffolding.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1060.wav", "emotion": "anger", "sentence": "She has been lying there for hours.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1061.wav", "emotion": "sadness", "sentence": "She has been lying there for hours.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1062.wav", "emotion": "sadness", "sentence": "She had eaten all of his favorite pastries.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1063.wav", "emotion": "anger", "sentence": "She had eaten all of his favorite pastries.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1064.wav", "emotion": "surprise", "sentence": "I just found out we have recess today!", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1065.wav", "emotion": "neutral", "sentence": "I just found out we have recess today!", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1066.wav", "emotion": "disgust", "sentence": "She ate her fish straight from the bones.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1067.wav", "emotion": "surprise", "sentence": "She ate her fish straight from the bones.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1068.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1069.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1070.wav", "emotion": "fear", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1071.wav", "emotion": "surprise", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1072.wav", "emotion": "surprise", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1073.wav", "emotion": "fear", "sentence": "I just saw someone walk into my shop covered from head-to-toe in tattoos.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1074.wav", "emotion": "surprise", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1075.wav", "emotion": "sadness", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1076.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1077.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1078.wav", "emotion": "fear", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1079.wav", "emotion": "surprise", "sentence": "I just spilled my spaghetti all over this crowded train.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1080.wav", "emotion": "surprise", "sentence": "You are about to be summoned.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1081.wav", "emotion": "fear", "sentence": "You are about to be summoned.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1082.wav", "emotion": "anger", "sentence": "I am so tired of this.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1083.wav", "emotion": "sadness", "sentence": "I am so tired of this.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1084.wav", "emotion": "surprise", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1085.wav", "emotion": "sadness", "sentence": "You've been coming here every Sunday for years and now you're doing puzzles instead of praying.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1086.wav", "emotion": "surprise", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1087.wav", "emotion": "joy", "sentence": "I just made so much noise I think everyone heard me from outside!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1088.wav", "emotion": "neutral", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1089.wav", "emotion": "surprise", "sentence": "I just found out I have been picking my nose for years.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1090.wav", "emotion": "joy", "sentence": "I never expected you would be sitting next me at this performance.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1091.wav", "emotion": "surprise", "sentence": "I never expected you would be sitting next me at this performance.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1092.wav", "emotion": "fear", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1093.wav", "emotion": "surprise", "sentence": "You really think you can control what happens when we use this thing?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1094.wav", "emotion": "fear", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1095.wav", "emotion": "anger", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1096.wav", "emotion": "surprise", "sentence": "You've finally hung those old curtains.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1097.wav", "emotion": "sadness", "sentence": "You've finally hung those old curtains.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1098.wav", "emotion": "joy", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1099.wav", "emotion": "surprise", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1100.wav", "emotion": "fear", "sentence": "He's running low.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1101.wav", "emotion": "surprise", "sentence": "He's running low.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1102.wav", "emotion": "sadness", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1103.wav", "emotion": "surprise", "sentence": "I just found out I have an appointment here today.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1104.wav", "emotion": "fear", "sentence": "She jumped out of her seat as he announced his candidacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1105.wav", "emotion": "surprise", "sentence": "She jumped out of her seat as he announced his candidacy.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1106.wav", "emotion": "sadness", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1107.wav", "emotion": "anger", "sentence": "She was wearing her favorite pair of broken headphones again.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1108.wav", "emotion": "surprise", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1109.wav", "emotion": "fear", "sentence": "You're eating Frooty-O's up here?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1110.wav", "emotion": "surprise", "sentence": "You're actually seeing me.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1111.wav", "emotion": "fear", "sentence": "You're actually seeing me.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1112.wav", "emotion": "fear", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1113.wav", "emotion": "sadness", "sentence": "You're going to have pay for this.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1114.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1115.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1116.wav", "emotion": "joy", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1117.wav", "emotion": "surprise", "sentence": "You just saved $10!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1118.wav", "emotion": "fear", "sentence": "I just saw my ex-partner walk into this room.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1119.wav", "emotion": "surprise", "sentence": "I just saw my ex-partner walk into this room.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1120.wav", "emotion": "fear", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1121.wav", "emotion": "surprise", "sentence": "I just saw my hairdresser pick up scissors and start cutting without even asking me what I wanted.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1122.wav", "emotion": "fear", "sentence": "You're standing too close.", "expected_emotions": ["fear", "disgust"]}
+{"filename": "1123.wav", "emotion": "disgust", "sentence": "You're standing too close.", "expected_emotions": ["fear", "disgust"]}
+{"filename": "1124.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1125.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1126.wav", "emotion": "surprise", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1127.wav", "emotion": "sadness", "sentence": "She pulled out all of her favorite flowers along with the weeds.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1128.wav", "emotion": "fear", "sentence": "She walked alone through the dark corridors of her new barracks.", "expected_emotions": ["fear", "neutral"]}
+{"filename": "1129.wav", "emotion": "neutral", "sentence": "She walked alone through the dark corridors of her new barracks.", "expected_emotions": ["fear", "neutral"]}
+{"filename": "1130.wav", "emotion": "fear", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1131.wav", "emotion": "anger", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1132.wav", "emotion": "neutral", "sentence": "You just made your first three-pointer.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1133.wav", "emotion": "surprise", "sentence": "You just made your first three-pointer.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1134.wav", "emotion": "sadness", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1135.wav", "emotion": "anger", "sentence": "I just spilled my new favorite flavor of smoothie all over this expensive shirt.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1136.wav", "emotion": "sadness", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1137.wav", "emotion": "fear", "sentence": "She's going for another shot.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1138.wav", "emotion": "fear", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1139.wav", "emotion": "surprise", "sentence": "She walked into her first day of college alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1140.wav", "emotion": "surprise", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1141.wav", "emotion": "sadness", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1142.wav", "emotion": "surprise", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1143.wav", "emotion": "fear", "sentence": "You are going to spill your hot coffee all over yourself.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1144.wav", "emotion": "fear", "sentence": "You're going too close to fast moving water.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1145.wav", "emotion": "surprise", "sentence": "You're going too close to fast moving water.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1146.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "1147.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "1148.wav", "emotion": "fear", "sentence": "She found something stuck between her teeth.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1149.wav", "emotion": "surprise", "sentence": "She found something stuck between her teeth.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1150.wav", "emotion": "neutral", "sentence": "You're taking another class today.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1151.wav", "emotion": "surprise", "sentence": "You're taking another class today.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1152.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1153.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1154.wav", "emotion": "surprise", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1155.wav", "emotion": "fear", "sentence": "You're going into those woods alone at night.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1156.wav", "emotion": "fear", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1157.wav", "emotion": "surprise", "sentence": "You are going to ride this bull!", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1158.wav", "emotion": "sadness", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1159.wav", "emotion": "surprise", "sentence": "You're wearing shorts at your job interview.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1160.wav", "emotion": "surprise", "sentence": "You're going to be late for your exam!", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1161.wav", "emotion": "fear", "sentence": "You're going to be late for your exam!", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1162.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1163.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1164.wav", "emotion": "surprise", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "1165.wav", "emotion": "disgust", "sentence": "She picked up her winning lottery ticket from off of the dirty casino bathroom floor.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "1166.wav", "emotion": "sadness", "sentence": "You're telling me I have to pay full price?", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1167.wav", "emotion": "surprise", "sentence": "You're telling me I have to pay full price?", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1168.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1169.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1170.wav", "emotion": "neutral", "sentence": "I am flying alone.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "1171.wav", "emotion": "sadness", "sentence": "I am flying alone.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "1172.wav", "emotion": "anger", "sentence": "She slammed her hand down on the table.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1173.wav", "emotion": "surprise", "sentence": "She slammed her hand down on the table.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1174.wav", "emotion": "surprise", "sentence": "She was running down from her room.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1175.wav", "emotion": "fear", "sentence": "She was running down from her room.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1176.wav", "emotion": "neutral", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "1177.wav", "emotion": "sadness", "sentence": "She has been waiting for hours.", "expected_emotions": ["neutral", "sadness"]}
+{"filename": "1178.wav", "emotion": "surprise", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1179.wav", "emotion": "sadness", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1180.wav", "emotion": "joy", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "1181.wav", "emotion": "fear", "sentence": "She was thrilled and terrified as she watched her favorite action hero narrowly escape death.", "expected_emotions": ["joy", "fear"]}
+{"filename": "1182.wav", "emotion": "fear", "sentence": "She just did an unexpected backflip.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1183.wav", "emotion": "surprise", "sentence": "She just did an unexpected backflip.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1184.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1185.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1186.wav", "emotion": "surprise", "sentence": "I have never dug this deep before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1187.wav", "emotion": "neutral", "sentence": "I have never dug this deep before.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1188.wav", "emotion": "fear", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1189.wav", "emotion": "surprise", "sentence": "I didn't expect my hands would slip like this.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1190.wav", "emotion": "surprise", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1191.wav", "emotion": "sadness", "sentence": "I just spilled my favorite soda all over myself while walking back from getting into this car.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1192.wav", "emotion": "disgust", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1193.wav", "emotion": "sadness", "sentence": "I have seen how communist ideals can be corrupted by those who claim to uphold them.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1194.wav", "emotion": "fear", "sentence": "You're going outside alone at night?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1195.wav", "emotion": "surprise", "sentence": "You're going outside alone at night?", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1196.wav", "emotion": "surprise", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1197.wav", "emotion": "fear", "sentence": "She didn't expect her opponent's shot to hit so close.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1198.wav", "emotion": "fear", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1199.wav", "emotion": "surprise", "sentence": "I just saw my personal trainer staring at me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1200.wav", "emotion": "sadness", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1201.wav", "emotion": "surprise", "sentence": "I just saw my former president walk by me.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1202.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1203.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1204.wav", "emotion": "fear", "sentence": "I just saw something big moving under water.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1205.wav", "emotion": "surprise", "sentence": "I just saw something big moving under water.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1206.wav", "emotion": "surprise", "sentence": "You're actually praying.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1207.wav", "emotion": "fear", "sentence": "You're actually praying.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1208.wav", "emotion": "surprise", "sentence": "You're really going for a hike wearing those sandals.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1209.wav", "emotion": "fear", "sentence": "You're really going for a hike wearing those sandals.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1210.wav", "emotion": "fear", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1211.wav", "emotion": "surprise", "sentence": "You're actually going outside for exercise today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1212.wav", "emotion": "fear", "sentence": "I am going for skydiving.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1213.wav", "emotion": "surprise", "sentence": "I am going for skydiving.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1214.wav", "emotion": "surprise", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1215.wav", "emotion": "sadness", "sentence": "I never thought I would be riding this bus again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1216.wav", "emotion": "surprise", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1217.wav", "emotion": "sadness", "sentence": "She hung up her wedding dress.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1218.wav", "emotion": "anger", "sentence": "You're still working here?", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1219.wav", "emotion": "sadness", "sentence": "You're still working here?", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1220.wav", "emotion": "fear", "sentence": "She was going outside alone at night.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1221.wav", "emotion": "sadness", "sentence": "She was going outside alone at night.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1222.wav", "emotion": "surprise", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1223.wav", "emotion": "fear", "sentence": "I just saw someone wearing my exact same costume.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1224.wav", "emotion": "sadness", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1225.wav", "emotion": "surprise", "sentence": "You're actually considering buying an AR-15 for hunting.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1226.wav", "emotion": "fear", "sentence": "You will be remembered here.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1227.wav", "emotion": "sadness", "sentence": "You will be remembered here.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1228.wav", "emotion": "surprise", "sentence": "You are wearing those shoes here.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "1229.wav", "emotion": "disgust", "sentence": "You are wearing those shoes here.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "1230.wav", "emotion": "fear", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1231.wav", "emotion": "surprise", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1232.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1233.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1234.wav", "emotion": "surprise", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1235.wav", "emotion": "fear", "sentence": "She left her dinner alone for just one minute and now there are birds eating off of her plate.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1236.wav", "emotion": "fear", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1237.wav", "emotion": "surprise", "sentence": "I just saw someone lift more than me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1238.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1239.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1240.wav", "emotion": "sadness", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1241.wav", "emotion": "surprise", "sentence": "I just got an unexpected message from my ex while I was checking emails at this beautiful secluded spot.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1242.wav", "emotion": "fear", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1243.wav", "emotion": "surprise", "sentence": "She just did the worm across the entire floor.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1244.wav", "emotion": "fear", "sentence": "I just realized I've had three cups already.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1245.wav", "emotion": "surprise", "sentence": "I just realized I've had three cups already.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1246.wav", "emotion": "sadness", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1247.wav", "emotion": "surprise", "sentence": "You're wearing those shoes again.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1248.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1249.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1250.wav", "emotion": "disgust", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1251.wav", "emotion": "sadness", "sentence": "She had been rinsing those same old plates for what felt like an eternity.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1252.wav", "emotion": "fear", "sentence": "She just walked into an abandoned house.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1253.wav", "emotion": "surprise", "sentence": "She just walked into an abandoned house.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1254.wav", "emotion": "disgust", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1255.wav", "emotion": "surprise", "sentence": "She killed a cockroach.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1256.wav", "emotion": "neutral", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1257.wav", "emotion": "surprise", "sentence": "I'm still here.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1258.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1259.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1260.wav", "emotion": "anger", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1261.wav", "emotion": "surprise", "sentence": "He just slapped her.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1262.wav", "emotion": "disgust", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1263.wav", "emotion": "sadness", "sentence": "You're surrounded by all this old dusty stuff.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1264.wav", "emotion": "surprise", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1265.wav", "emotion": "sadness", "sentence": "She took one last photo of her hair before cutting off all those years.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1266.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1267.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1268.wav", "emotion": "anger", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
+{"filename": "1269.wav", "emotion": "fear", "sentence": "She watched as he placed his symbol of hate upon their sacred space.", "expected_emotions": ["anger", "fear"]}
+{"filename": "1270.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1271.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1272.wav", "emotion": "surprise", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1273.wav", "emotion": "fear", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1274.wav", "emotion": "surprise", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1275.wav", "emotion": "neutral", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1276.wav", "emotion": "fear", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1277.wav", "emotion": "surprise", "sentence": "She held his hand as they stepped into the empty elevator.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1278.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1279.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1280.wav", "emotion": "fear", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1281.wav", "emotion": "surprise", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1282.wav", "emotion": "sadness", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1283.wav", "emotion": "anger", "sentence": "I've been working non-stop for months and I still can't get any rest.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1284.wav", "emotion": "fear", "sentence": "She just saw her boss walking towards their table.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1285.wav", "emotion": "surprise", "sentence": "She just saw her boss walking towards their table.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1286.wav", "emotion": "anger", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1287.wav", "emotion": "surprise", "sentence": "You just spilled an entire glass of red wine all over your new white shirt!", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1288.wav", "emotion": "anger", "sentence": "You're going too close.", "expected_emotions": ["anger", "fear"]}
+{"filename": "1289.wav", "emotion": "fear", "sentence": "You're going too close.", "expected_emotions": ["anger", "fear"]}
+{"filename": "1290.wav", "emotion": "neutral", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1291.wav", "emotion": "surprise", "sentence": "You're going to be just fine.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1292.wav", "emotion": "sadness", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1293.wav", "emotion": "anger", "sentence": "She had just spilled an entire tray of petri dishes.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1294.wav", "emotion": "surprise", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1295.wav", "emotion": "fear", "sentence": "She finally found what she was looking for down there.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1296.wav", "emotion": "sadness", "sentence": "I just threw away my career.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1297.wav", "emotion": "disgust", "sentence": "I just threw away my career.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1298.wav", "emotion": "surprise", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1299.wav", "emotion": "neutral", "sentence": "You are walking alone through this empty and darkened place.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1300.wav", "emotion": "surprise", "sentence": "You are going to be photographed.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1301.wav", "emotion": "fear", "sentence": "You are going to be photographed.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1302.wav", "emotion": "fear", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1303.wav", "emotion": "anger", "sentence": "She can't believe he's telling another terrible joke.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1304.wav", "emotion": "surprise", "sentence": "She just blew her first bubble.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1305.wav", "emotion": "joy", "sentence": "She just blew her first bubble.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1306.wav", "emotion": "sadness", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "1307.wav", "emotion": "joy", "sentence": "She danced alone at her birthday party.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "1308.wav", "emotion": "surprise", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1309.wav", "emotion": "fear", "sentence": "He just dunked over three people.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1310.wav", "emotion": "surprise", "sentence": "I never thought I'd be staying here by myself.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1311.wav", "emotion": "sadness", "sentence": "I never thought I'd be staying here by myself.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1312.wav", "emotion": "fear", "sentence": "I didn't expect them to find me hiding here.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1313.wav", "emotion": "surprise", "sentence": "I didn't expect them to find me hiding here.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1314.wav", "emotion": "surprise", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1315.wav", "emotion": "fear", "sentence": "You're going to be released from this place today.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1316.wav", "emotion": "sadness", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1317.wav", "emotion": "surprise", "sentence": "I never thought I'd be doing this again after what happened.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1318.wav", "emotion": "fear", "sentence": "She brought her phone into an area where phones were strictly prohibited.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1319.wav", "emotion": "surprise", "sentence": "She brought her phone into an area where phones were strictly prohibited.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1320.wav", "emotion": "anger", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1321.wav", "emotion": "surprise", "sentence": "You're telling me I need another root canal?", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1322.wav", "emotion": "surprise", "sentence": "He walked into an empty lecture hall wearing only his gym clothes.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "1323.wav", "emotion": "disgust", "sentence": "He walked into an empty lecture hall wearing only his gym clothes.", "expected_emotions": ["surprise", "disgust"]}
+{"filename": "1324.wav", "emotion": "surprise", "sentence": "I just saw something move down here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1325.wav", "emotion": "fear", "sentence": "I just saw something move down here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1326.wav", "emotion": "surprise", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1327.wav", "emotion": "sadness", "sentence": "She wore her late mother's swimsuit.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1328.wav", "emotion": "sadness", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1329.wav", "emotion": "fear", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1330.wav", "emotion": "sadness", "sentence": "You're really cutting off all of your hair.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1331.wav", "emotion": "surprise", "sentence": "You're really cutting off all of your hair.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1332.wav", "emotion": "surprise", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1333.wav", "emotion": "fear", "sentence": "She ran down the hallway of the courthouse.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1334.wav", "emotion": "surprise", "sentence": "You're actually dancing out here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1335.wav", "emotion": "fear", "sentence": "You're actually dancing out here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1336.wav", "emotion": "surprise", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1337.wav", "emotion": "neutral", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1338.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1339.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1340.wav", "emotion": "sadness", "sentence": "I just found out they're closing this location down.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1341.wav", "emotion": "surprise", "sentence": "I just found out they're closing this location down.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1342.wav", "emotion": "sadness", "sentence": "You finally made par.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "1343.wav", "emotion": "joy", "sentence": "You finally made par.", "expected_emotions": ["sadness", "joy"]}
+{"filename": "1344.wav", "emotion": "surprise", "sentence": "You are going to be kissed by your crush.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1345.wav", "emotion": "joy", "sentence": "You are going to be kissed by your crush.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1346.wav", "emotion": "fear", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1347.wav", "emotion": "surprise", "sentence": "I just saw my ex walk into this crowded nightclub.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1348.wav", "emotion": "fear", "sentence": "He's been talking like this for years and now he finally has an audience.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1349.wav", "emotion": "anger", "sentence": "He's been talking like this for years and now he finally has an audience.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1350.wav", "emotion": "fear", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1351.wav", "emotion": "surprise", "sentence": "You're going downstairs alone.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1352.wav", "emotion": "surprise", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1353.wav", "emotion": "sadness", "sentence": "I just realized I have been playing this game for hours.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1354.wav", "emotion": "surprise", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1355.wav", "emotion": "sadness", "sentence": "You're buying just one item.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1356.wav", "emotion": "fear", "sentence": "She can't afford another loss.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1357.wav", "emotion": "sadness", "sentence": "She can't afford another loss.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1358.wav", "emotion": "disgust", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1359.wav", "emotion": "surprise", "sentence": "She just ordered fried insects as an appetizer.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1360.wav", "emotion": "fear", "sentence": "She's getting her first tattoo.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1361.wav", "emotion": "surprise", "sentence": "She's getting her first tattoo.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1362.wav", "emotion": "fear", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1363.wav", "emotion": "surprise", "sentence": "She ran around the ancient stone alter as if something was chasing her.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1364.wav", "emotion": "fear", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1365.wav", "emotion": "surprise", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1366.wav", "emotion": "surprise", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1367.wav", "emotion": "sadness", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1368.wav", "emotion": "fear", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1369.wav", "emotion": "sadness", "sentence": "I am not sure if I will be able to make my wedding day.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1370.wav", "emotion": "surprise", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1371.wav", "emotion": "anger", "sentence": "I can't believe I finally found something.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1372.wav", "emotion": "surprise", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1373.wav", "emotion": "neutral", "sentence": "She drove down this same rural route every day and never once saw another car.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1374.wav", "emotion": "fear", "sentence": "She kissed him right next to her ex's portrait.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1375.wav", "emotion": "surprise", "sentence": "She kissed him right next to her ex's portrait.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1376.wav", "emotion": "sadness", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1377.wav", "emotion": "surprise", "sentence": "You're really going for another lap around this track.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1378.wav", "emotion": "surprise", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1379.wav", "emotion": "neutral", "sentence": "You're going shirtless around here.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1380.wav", "emotion": "surprise", "sentence": "I just saw someone hanging by their feet at the playground.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1381.wav", "emotion": "fear", "sentence": "I just saw someone hanging by their feet at the playground.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1382.wav", "emotion": "fear", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1383.wav", "emotion": "surprise", "sentence": "You've placed something sacred upon this pedestal.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1384.wav", "emotion": "sadness", "sentence": "You are leaving me.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1385.wav", "emotion": "fear", "sentence": "You are leaving me.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1386.wav", "emotion": "surprise", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1387.wav", "emotion": "anger", "sentence": "You're actually going for the top shelf.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1388.wav", "emotion": "sadness", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1389.wav", "emotion": "surprise", "sentence": "You're actually picking wildflowers from our green.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1390.wav", "emotion": "sadness", "sentence": "She stood alone at her pew.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "1391.wav", "emotion": "neutral", "sentence": "She stood alone at her pew.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "1392.wav", "emotion": "surprise", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1393.wav", "emotion": "fear", "sentence": "She got splashed by an unexpected wave.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1394.wav", "emotion": "fear", "sentence": "I never thought I would be getting my blood drawn today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1395.wav", "emotion": "surprise", "sentence": "I never thought I would be getting my blood drawn today.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1396.wav", "emotion": "fear", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1397.wav", "emotion": "surprise", "sentence": "She just gave her life savings away for free.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1398.wav", "emotion": "surprise", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1399.wav", "emotion": "fear", "sentence": "She never expected him to kiss her like this.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1400.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1401.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1402.wav", "emotion": "sadness", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1403.wav", "emotion": "surprise", "sentence": "I just realized I've been putting this shirt on inside out for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1404.wav", "emotion": "surprise", "sentence": "I just realized I've been eating this stuff for years.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1405.wav", "emotion": "fear", "sentence": "I just realized I've been eating this stuff for years.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1406.wav", "emotion": "fear", "sentence": "I just received an urgent message from my boss while I was wearing these new noise-cancelling headphones.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1407.wav", "emotion": "surprise", "sentence": "I just received an urgent message from my boss while I was wearing these new noise-cancelling headphones.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1408.wav", "emotion": "fear", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1409.wav", "emotion": "sadness", "sentence": "You are going to get hurt.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1410.wav", "emotion": "fear", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1411.wav", "emotion": "surprise", "sentence": "She was dancing alone at night near an abandoned funhouse.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1412.wav", "emotion": "surprise", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1413.wav", "emotion": "fear", "sentence": "You're going near those heavy machines without your hard hat?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1414.wav", "emotion": "fear", "sentence": "She was going bald.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1415.wav", "emotion": "sadness", "sentence": "She was going bald.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1416.wav", "emotion": "fear", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1417.wav", "emotion": "surprise", "sentence": "You are about to be called up onto this stage.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1418.wav", "emotion": "surprise", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1419.wav", "emotion": "fear", "sentence": "I am going for skydiving.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1420.wav", "emotion": "fear", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1421.wav", "emotion": "surprise", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1422.wav", "emotion": "surprise", "sentence": "I just saw my ex standing behind me.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1423.wav", "emotion": "fear", "sentence": "I just saw my ex standing behind me.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1424.wav", "emotion": "sadness", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1425.wav", "emotion": "fear", "sentence": "I'm not sure if I should be putting this offering of french fries here.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1426.wav", "emotion": "fear", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1427.wav", "emotion": "surprise", "sentence": "I just heard footsteps coming from inside this abandoned temple.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1428.wav", "emotion": "fear", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1429.wav", "emotion": "surprise", "sentence": "You are now operating this massive machine.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1430.wav", "emotion": "fear", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1431.wav", "emotion": "surprise", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1432.wav", "emotion": "fear", "sentence": "I'm having triplets.", "expected_emotions": ["fear", "joy"]}
+{"filename": "1433.wav", "emotion": "joy", "sentence": "I'm having triplets.", "expected_emotions": ["fear", "joy"]}
+{"filename": "1434.wav", "emotion": "anger", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1435.wav", "emotion": "surprise", "sentence": "She just spent her entire paycheck at this tiny little print shop.", "expected_emotions": ["anger", "surprise"]}
+{"filename": "1436.wav", "emotion": "surprise", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1437.wav", "emotion": "sadness", "sentence": "I just got another call about an emergency surgery.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1438.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1439.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1440.wav", "emotion": "surprise", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1441.wav", "emotion": "sadness", "sentence": "I never thought I'd be playing my guitar again.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1442.wav", "emotion": "sadness", "sentence": "You're really going all out and paying full price.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1443.wav", "emotion": "surprise", "sentence": "You're really going all out and paying full price.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1444.wav", "emotion": "surprise", "sentence": "He just knocked over an entire stack of bricks.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1445.wav", "emotion": "anger", "sentence": "He just knocked over an entire stack of bricks.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1446.wav", "emotion": "joy", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1447.wav", "emotion": "surprise", "sentence": "You are going to love this flight.", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1448.wav", "emotion": "fear", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1449.wav", "emotion": "surprise", "sentence": "I just realized I have been struggling for months.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1450.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1451.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1452.wav", "emotion": "surprise", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1453.wav", "emotion": "fear", "sentence": "You're actually going out there and playing after what happened last game.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1454.wav", "emotion": "surprise", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1455.wav", "emotion": "fear", "sentence": "She's going down black diamond.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1456.wav", "emotion": "sadness", "sentence": "She stared at her painting as if she was seeing something different.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "1457.wav", "emotion": "neutral", "sentence": "She stared at her painting as if she was seeing something different.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "1458.wav", "emotion": "joy", "sentence": "I'm having triplets.", "expected_emotions": ["joy", "fear"]}
+{"filename": "1459.wav", "emotion": "fear", "sentence": "I'm having triplets.", "expected_emotions": ["joy", "fear"]}
+{"filename": "1460.wav", "emotion": "sadness", "sentence": "She stood up and walked out of her own wedding.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1461.wav", "emotion": "surprise", "sentence": "She stood up and walked out of her own wedding.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1462.wav", "emotion": "fear", "sentence": "She swerved across three lanes of traffic.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1463.wav", "emotion": "surprise", "sentence": "She swerved across three lanes of traffic.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1464.wav", "emotion": "fear", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1465.wav", "emotion": "surprise", "sentence": "I just realized I have been traveling through this vast and arid landscape for days now.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1466.wav", "emotion": "sadness", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1467.wav", "emotion": "surprise", "sentence": "I have never seen so many broken items come through this door.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1468.wav", "emotion": "joy", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1469.wav", "emotion": "surprise", "sentence": "You're actually wearing your sunglasses!", "expected_emotions": ["joy", "surprise"]}
+{"filename": "1470.wav", "emotion": "fear", "sentence": "She just saw him standing there.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1471.wav", "emotion": "surprise", "sentence": "She just saw him standing there.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1472.wav", "emotion": "sadness", "sentence": "She has been waiting for hours.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "1473.wav", "emotion": "neutral", "sentence": "She has been waiting for hours.", "expected_emotions": ["sadness", "neutral"]}
+{"filename": "1474.wav", "emotion": "disgust", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1475.wav", "emotion": "sadness", "sentence": "She wore her favorite designer dress for what would be their last performance together.", "expected_emotions": ["disgust", "sadness"]}
+{"filename": "1476.wav", "emotion": "surprise", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1477.wav", "emotion": "anger", "sentence": "You left your dirty socks right next to my toothbrush.", "expected_emotions": ["surprise", "anger"]}
+{"filename": "1478.wav", "emotion": "fear", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1479.wav", "emotion": "surprise", "sentence": "I didn't think I'd be here this long.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1480.wav", "emotion": "sadness", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1481.wav", "emotion": "fear", "sentence": "I'm going outside alone.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1482.wav", "emotion": "fear", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1483.wav", "emotion": "surprise", "sentence": "You are standing alone at an altar.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1484.wav", "emotion": "surprise", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1485.wav", "emotion": "sadness", "sentence": "You're still wearing your grandmother's locket even though you know silver reacts poorly with photographic chemicals.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1486.wav", "emotion": "fear", "sentence": "You're actually going up there and giving a speech.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1487.wav", "emotion": "surprise", "sentence": "You're actually going up there and giving a speech.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1488.wav", "emotion": "sadness", "sentence": "She was alone and surrounded by darkness.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1489.wav", "emotion": "fear", "sentence": "She was alone and surrounded by darkness.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1490.wav", "emotion": "sadness", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1491.wav", "emotion": "surprise", "sentence": "You find yourself standing alone at an altar.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1492.wav", "emotion": "fear", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1493.wav", "emotion": "surprise", "sentence": "She jumped into the deep end of her family's swimming pool.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1494.wav", "emotion": "sadness", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1495.wav", "emotion": "surprise", "sentence": "She just found out she has been taking cold showers for years.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1496.wav", "emotion": "sadness", "sentence": "You're still listening to music.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1497.wav", "emotion": "surprise", "sentence": "You're still listening to music.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1498.wav", "emotion": "neutral", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1499.wav", "emotion": "surprise", "sentence": "She brought her math textbook and calculator into the arena.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1500.wav", "emotion": "fear", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1501.wav", "emotion": "surprise", "sentence": "I just got pushed out of my seat and now I'm standing.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1502.wav", "emotion": "fear", "sentence": "She was caught off guard by his sudden appearance.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1503.wav", "emotion": "surprise", "sentence": "She was caught off guard by his sudden appearance.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1504.wav", "emotion": "surprise", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1505.wav", "emotion": "fear", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1506.wav", "emotion": "surprise", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1507.wav", "emotion": "fear", "sentence": "She had never thought she would be having this conversation at her age.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1508.wav", "emotion": "fear", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1509.wav", "emotion": "sadness", "sentence": "I am wearing this outfit because I have nothing else left.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1510.wav", "emotion": "sadness", "sentence": "I just lit up my last pack of cigarettes.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1511.wav", "emotion": "fear", "sentence": "I just lit up my last pack of cigarettes.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1512.wav", "emotion": "fear", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1513.wav", "emotion": "anger", "sentence": "You're going too far out there.", "expected_emotions": ["fear", "anger"]}
+{"filename": "1514.wav", "emotion": "surprise", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1515.wav", "emotion": "joy", "sentence": "I just saw my favorite politician running towards me.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1516.wav", "emotion": "neutral", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1517.wav", "emotion": "surprise", "sentence": "I just found my old childhood TV.", "expected_emotions": ["neutral", "surprise"]}
+{"filename": "1518.wav", "emotion": "sadness", "sentence": "You are leaving me alone again.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1519.wav", "emotion": "disgust", "sentence": "You are leaving me alone again.", "expected_emotions": ["sadness", "disgust"]}
+{"filename": "1520.wav", "emotion": "surprise", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1521.wav", "emotion": "sadness", "sentence": "You're leaving without buying anything.", "expected_emotions": ["surprise", "sadness"]}
+{"filename": "1522.wav", "emotion": "surprise", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1523.wav", "emotion": "joy", "sentence": "You're wearing lipstick at work today.", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1524.wav", "emotion": "sadness", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1525.wav", "emotion": "surprise", "sentence": "You are actually buying this mink coat.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1526.wav", "emotion": "surprise", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1527.wav", "emotion": "fear", "sentence": "I just realized I am completely alone here.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1528.wav", "emotion": "sadness", "sentence": "She just cut her nail too short.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1529.wav", "emotion": "surprise", "sentence": "She just cut her nail too short.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1530.wav", "emotion": "fear", "sentence": "You're going to have to try this outfit again.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1531.wav", "emotion": "surprise", "sentence": "You're going to have to try this outfit again.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1532.wav", "emotion": "surprise", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1533.wav", "emotion": "fear", "sentence": "You're going to have to get used to seeing people's bodies covered in needles and ink.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1534.wav", "emotion": "disgust", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1535.wav", "emotion": "surprise", "sentence": "I just saw someone taking an outdoor shower at this camp site.", "expected_emotions": ["disgust", "surprise"]}
+{"filename": "1536.wav", "emotion": "surprise", "sentence": "She just flushed something down there.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1537.wav", "emotion": "fear", "sentence": "She just flushed something down there.", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1538.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1539.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["fear", "sadness"]}
+{"filename": "1540.wav", "emotion": "fear", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1541.wav", "emotion": "surprise", "sentence": "You are going to have to explain why there's a picture of our president hanging next to your favorite cartoon character.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1542.wav", "emotion": "surprise", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1543.wav", "emotion": "joy", "sentence": "You're actually buying organic produce!", "expected_emotions": ["surprise", "joy"]}
+{"filename": "1544.wav", "emotion": "sadness", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1545.wav", "emotion": "anger", "sentence": "She was crying while she washed her hands.", "expected_emotions": ["sadness", "anger"]}
+{"filename": "1546.wav", "emotion": "surprise", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1547.wav", "emotion": "fear", "sentence": "You're really going out there without wearing any protection?", "expected_emotions": ["surprise", "fear"]}
+{"filename": "1548.wav", "emotion": "surprise", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1549.wav", "emotion": "neutral", "sentence": "I am sitting at an unusual height.", "expected_emotions": ["surprise", "neutral"]}
+{"filename": "1550.wav", "emotion": "anger", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1551.wav", "emotion": "sadness", "sentence": "I have been walking these hospital floors for years.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1552.wav", "emotion": "sadness", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1553.wav", "emotion": "fear", "sentence": "She stood alone at her grandmother's grave.", "expected_emotions": ["sadness", "fear"]}
+{"filename": "1554.wav", "emotion": "sadness", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1555.wav", "emotion": "surprise", "sentence": "She had never seen her photos turn out so poorly before.", "expected_emotions": ["sadness", "surprise"]}
+{"filename": "1556.wav", "emotion": "anger", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1557.wav", "emotion": "sadness", "sentence": "I just spent my entire paycheck at this overpriced bowling alley.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1558.wav", "emotion": "fear", "sentence": "You're actually seeing me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1559.wav", "emotion": "surprise", "sentence": "You're actually seeing me.", "expected_emotions": ["fear", "surprise"]}
+{"filename": "1560.wav", "emotion": "anger", "sentence": "I cant believe you did this.", "expected_emotions": ["anger", "sadness"]}
+{"filename": "1561.wav", "emotion": "sadness", "sentence": "I cant believe you did this.", "expected_emotions": ["anger", "sadness"]}


### PR DESCRIPTION
Fixes #30 

The EmoCF paths are all long uuids not 0.wav, 1.wav, etc. as the download from huggingface script expects.

**NOTE:** This should undergo a careful review as I just renamed the rows 1:1 based on their position in the jsonl.  I did not check that the audio aligns with the row anymore.  If the mapping is incorrect this could lead to subtle issues.  I also didn't rerun the benchmarking code after making this change, so it is worth checking that the system works end to end.